### PR TITLE
feat: allow skipping onboarding with persistent preference

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -236,10 +236,16 @@ function MapPageContent() {
     setHasCompletedOnboarding(true);
   };
 
+  const handleOnboardingSkip = () => {
+    localStorage.setItem('onboarding-completed', 'skipped');
+    setShowOnboarding(false);
+    setHasCompletedOnboarding(true);
+  };
+
   if (!isMounted) return <MapSkeleton />;
 
   if (showOnboarding && availableRoutes.length > 0) {
-    return <OnboardingFlow availableRoutes={availableRoutes} onComplete={handleOnboardingComplete} />;
+    return <OnboardingFlow availableRoutes={availableRoutes} onComplete={handleOnboardingComplete} onSkip={handleOnboardingSkip} />;
   }
 
   return (
@@ -418,7 +424,7 @@ function MapPageContent() {
           </div>
         )}
 
-        {showAboutModal && <AboutModal onClose={() => setShowAboutModal(false)} />}
+        {showAboutModal && <AboutModal onClose={() => setShowAboutModal(false)} onResetOnboarding={() => { localStorage.removeItem('onboarding-completed'); setShowAboutModal(false); setShowOnboarding(true); setHasCompletedOnboarding(false); }} />}
       </main>
     </div>
   );

--- a/components/AboutModal.tsx
+++ b/components/AboutModal.tsx
@@ -2,9 +2,10 @@
 
 interface AboutModalProps {
   onClose: () => void;
+  onResetOnboarding: () => void;
 }
 
-export function AboutModal({ onClose }: AboutModalProps) {
+export function AboutModal({ onClose, onResetOnboarding }: AboutModalProps) {
   return (
     <div
       className="fixed inset-0 bg-black bg-opacity-50 z-[2000] flex items-center justify-center p-4"
@@ -61,6 +62,15 @@ export function AboutModal({ onClose }: AboutModalProps) {
 
           <div className="text-xs text-gray-500 dark:text-gray-400 pt-2">
             Dados fornecidos pela API OpenTripPlanner do Porto
+          </div>
+
+          <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
+            <button
+              onClick={onResetOnboarding}
+              className="text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors"
+            >
+              🔄 Repetir introdução
+            </button>
           </div>
 
           <div className="text-xs text-gray-400 dark:text-gray-500 pt-2 font-mono">

--- a/components/OnboardingFlow.tsx
+++ b/components/OnboardingFlow.tsx
@@ -5,9 +5,10 @@ import { useState, useEffect } from "react";
 interface OnboardingFlowProps {
   availableRoutes: string[];
   onComplete: (selectedRoutes: string[], locationGranted: boolean) => void;
+  onSkip: () => void;
 }
 
-export function OnboardingFlow({ availableRoutes, onComplete }: OnboardingFlowProps) {
+export function OnboardingFlow({ availableRoutes, onComplete, onSkip }: OnboardingFlowProps) {
   const [step, setStep] = useState(0);
   const [selectedRoutes, setSelectedRoutes] = useState<string[]>([]);
   const [isRequestingLocation, setIsRequestingLocation] = useState(false);
@@ -106,6 +107,12 @@ export function OnboardingFlow({ availableRoutes, onComplete }: OnboardingFlowPr
               className="w-full py-4 px-8 bg-blue-600 hover:bg-blue-700 text-white rounded-2xl font-semibold text-lg shadow-lg transition-all transform hover:scale-105"
             >
               Começar
+            </button>
+            <button
+              onClick={onSkip}
+              className="mt-4 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 text-sm transition-colors"
+            >
+              Saltar tudo
             </button>
           </div>
         )}


### PR DESCRIPTION
## Summary

Allows users to skip the entire onboarding flow and remember that decision. Users can re-trigger onboarding later from the About modal.

Closes #5

### Changes

**OnboardingFlow.tsx**
- Added `onSkip` prop
- Added "Saltar tudo" link below the "Começar" button on the welcome screen (step 0)

**page.tsx**
- Added `handleOnboardingSkip` that stores `'skipped'` in localStorage (distinguishable from `'true'` for full completion)
- Wired `onResetOnboarding` to clear localStorage and re-show onboarding

**AboutModal.tsx**
- Added `onResetOnboarding` prop
- Added "🔄 Repetir introdução" button so users can re-trigger onboarding

### Acceptance Criteria
- [x] Welcome screen shows "Saltar tudo" link below "Começar"
- [x] Clicking skip immediately shows the map with no filters
- [x] Decision persists across sessions (localStorage)
- [x] Users can re-trigger onboarding from About modal
- [x] Skip preference is distinguishable from full completion (`'skipped'` vs `'true'`)