### PR TITLE
feat: improve map UX with new stop icons, metro markers, map styles, and tile buffering

### DIFF
--- a/app/api/stations/route.ts
+++ b/app/api/stations/route.ts
@@ -15,7 +15,7 @@ export async function GET() {
         Origin: "https://explore.porto.pt",
       },
       body: JSON.stringify({
-        query: `query { stops { id code desc lat lon name gtfsId } }`,
+        query: `query { stops { id code desc lat lon name gtfsId vehicleMode } }`,
       }),
     });
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -164,7 +164,7 @@ body {
   margin-top: 8px;
   padding: 6px 12px;
   background: var(--color-accent);
-  color: var(--color-content-inverse);
+  color: #ffffff;
   text-decoration: none;
   border-radius: 4px;
   font-size: 12px;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -77,6 +77,12 @@ function MapPageContent() {
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [hasCompletedOnboarding, setHasCompletedOnboarding] = useState(false);
   const [showLocationSuccess, setShowLocationSuccess] = useState(false);
+  const [mapStyle, setMapStyle] = useState(() => {
+    if (typeof window !== "undefined") {
+      return localStorage.getItem("mapStyle") || "standard";
+    }
+    return "standard";
+  });
 
   // Feedback state for bottom sheet (triggered by bus popup custom event)
   const [showFeedbackSheet, setShowFeedbackSheet] = useState(false);
@@ -341,6 +347,7 @@ function MapPageContent() {
   useEffect(() => { localStorage.setItem("favoriteRoutes", JSON.stringify(favoriteRoutes)); }, [favoriteRoutes]);
   useEffect(() => { localStorage.setItem("showStops", JSON.stringify(showStops)); }, [showStops]);
   useEffect(() => { localStorage.setItem("showRoutes", JSON.stringify(showRoutes)); }, [showRoutes]);
+  useEffect(() => { localStorage.setItem("mapStyle", mapStyle); }, [mapStyle]);
   useEffect(() => { localStorage.setItem("showRouteFilter", JSON.stringify(showRouteFilter)); }, [showRouteFilter]);
   useEffect(() => { localStorage.setItem("showBikeParks", JSON.stringify(showBikeParks)); }, [showBikeParks]);
   useEffect(() => { localStorage.setItem("showBikeLanes", JSON.stringify(showBikeLanes)); }, [showBikeLanes]);
@@ -632,6 +639,7 @@ function MapPageContent() {
             showBikeParks={showBikeParks}
             showBikeLanes={showBikeLanes}
             selectedBikeLanes={selectedBikeLanes}
+            mapStyle={mapStyle}
           />
         ) : (
           <div className="h-full w-full flex items-center justify-center">
@@ -645,7 +653,7 @@ function MapPageContent() {
           </div>
         )}
 
-        {showSettings && <SettingsModal onClose={() => setShowSettings(false)} onResetOnboarding={() => { localStorage.removeItem('onboarding-completed'); setShowSettings(false); setShowOnboarding(true); setHasCompletedOnboarding(false); }} />}
+        {showSettings && <SettingsModal onClose={() => setShowSettings(false)} onResetOnboarding={() => { localStorage.removeItem('onboarding-completed'); setShowSettings(false); setShowOnboarding(true); setHasCompletedOnboarding(false); }} mapStyle={mapStyle} onMapStyleChange={setMapStyle} />}
 
         {/* Line Feedback Bottom Sheet */}
         <BottomSheet

--- a/app/reviews/line/page.tsx
+++ b/app/reviews/line/page.tsx
@@ -77,7 +77,7 @@ function RouteMap({ patterns, stops, lineId }: { patterns: LinePattern[]; stops:
         document.head.appendChild(css);
       }
 
-      const map = L.map(mapRef.current, { zoomControl: false, attributionControl: false }).setView([41.1579, -8.6291], 13);
+      const map = L.map(mapRef.current, { zoomControl: false, attributionControl: false, maxZoom: 19 }).setView([41.1579, -8.6291], 13);
       mapInstanceRef.current = map;
 
       L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
@@ -124,11 +124,19 @@ function RouteMap({ patterns, stops, lineId }: { patterns: LinePattern[]; stops:
       // Draw stop markers
       activeStops.forEach((stop, i) => {
         const isTerminal = i === 0 || i === activeStops.length - 1;
+        const size = isTerminal ? 32 : 24;
+        const vb = "0 0 20 24";
         const icon = L.divIcon({
-          html: `<div style="width:${isTerminal ? 14 : 8}px;height:${isTerminal ? 14 : 8}px;background:${isTerminal ? "#3b82f6" : "#ef4444"};border:2px solid white;border-radius:50%;box-shadow:0 1px 3px rgba(0,0,0,0.4);"></div>`,
+          html: `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size * 1.2}" viewBox="${vb}" style="filter:drop-shadow(0 1px 2px rgba(0,0,0,0.3));">
+            <rect x="9" y="8" width="2" height="16" rx="1" fill="#5f6368"/>
+            <rect x="2" y="0" width="16" height="12" rx="2.5" fill="${isTerminal ? "#0d9488" : "#6b7280"}" stroke="white" stroke-width="1"/>
+            <path d="M6.5 3.5h7a1 1 0 011 1v2.5a1 1 0 01-1 1h-7a1 1 0 01-1-1V4.5a1 1 0 011-1z" fill="white" opacity="0.9"/>
+            <rect x="6" y="8.5" width="3" height="1.5" rx="0.5" fill="white" opacity="0.7"/>
+            <rect x="11" y="8.5" width="3" height="1.5" rx="0.5" fill="white" opacity="0.7"/>
+          </svg>`,
           className: "line-stop-marker",
-          iconSize: [isTerminal ? 14 : 8, isTerminal ? 14 : 8],
-          iconAnchor: [isTerminal ? 7 : 4, isTerminal ? 7 : 4],
+          iconSize: [size, size * 1.2],
+          iconAnchor: [size / 2, size * 1.2],
         });
 
         L.marker([stop.lat, stop.lon], { icon })

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -9,9 +9,11 @@ import { AuthModal } from "@/components/AuthModal";
 interface SettingsModalProps {
   onClose: () => void;
   onResetOnboarding?: () => void;
+  mapStyle?: string;
+  onMapStyleChange?: (style: string) => void;
 }
 
-export function SettingsModal({ onClose, onResetOnboarding }: SettingsModalProps) {
+export function SettingsModal({ onClose, onResetOnboarding, mapStyle, onMapStyleChange }: SettingsModalProps) {
   const t = useTranslations();
   const { locale, setLocale } = useLocale();
   const { user, isAuthenticated, logout } = useAuth();
@@ -127,6 +129,35 @@ export function SettingsModal({ onClose, onResetOnboarding }: SettingsModalProps
 
           {/* Account */}
           <div>
+
+          {/* Map Style */}
+          {mapStyle && onMapStyleChange && (
+            <div>
+              <h3 className="text-xs font-semibold text-content-muted uppercase tracking-wide mb-2">
+                {t.settings.mapStyle}
+              </h3>
+              <div className="flex gap-2">
+                {([
+                  { key: "standard", label: t.settings.mapStandard, icon: "🗺️" },
+                  { key: "satellite", label: t.settings.mapSatellite, icon: "🛰️" },
+                  { key: "terrain", label: t.settings.mapTerrain, icon: "⛰️" },
+                ] as const).map(({ key, label, icon }) => (
+                  <button
+                    key={key}
+                    onClick={() => onMapStyleChange(key)}
+                    className={`flex-1 py-2.5 px-3 rounded-lg text-sm font-medium transition-colors ${
+                      mapStyle === key
+                        ? "bg-accent text-white"
+                        : "bg-surface-sunken text-content-secondary hover:bg-border"
+                    }`}
+                  >
+                    {icon} {label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
             <h3 className="text-xs font-semibold text-content-muted uppercase tracking-wide mb-2">
               {t.auth.account}
             </h3>

--- a/lib/schemas/otp.ts
+++ b/lib/schemas/otp.ts
@@ -17,6 +17,7 @@ export const OTPStopSchema = z.object({
   lon: z.number(),
   name: z.string(),
   gtfsId: z.string(),
+  vehicleMode: z.string().nullable().optional(),
 });
 
 export const OTPStopsResponseSchema = z.object({

--- a/lib/translations.ts
+++ b/lib/translations.ts
@@ -191,6 +191,10 @@ const pt = {
     dataProvider: "Dados fornecidos pela API OpenTripPlanner do Porto",
     resetOnboarding: "Repetir introdução",
     version: "Versão",
+    mapStyle: "Estilo do mapa",
+    mapStandard: "Padrão",
+    mapSatellite: "Satélite",
+    mapTerrain: "Terreno",
   },
   auth: {
     loginTitle: "Iniciar sessão",
@@ -436,6 +440,10 @@ const en: typeof pt = {
     dataProvider: "Data provided by Porto's OpenTripPlanner API",
     resetOnboarding: "Restart onboarding",
     version: "Version",
+    mapStyle: "Map style",
+    mapStandard: "Standard",
+    mapSatellite: "Satellite",
+    mapTerrain: "Terrain",
   },
   auth: {
     loginTitle: "Sign in",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -26,6 +26,7 @@ export interface Stop {
   lon: number;
   name: string;
   gtfsId: string;
+  vehicleMode?: string | null;
 }
 
 export interface StopsResponse {


### PR DESCRIPTION
## Summary

Overhaul of the map stop markers and overall map UX, addressing visual clutter, accessibility, and usability.

### Changes

**Stop Icons**
- Replaced obnoxious red dot markers with clean SVG bus stop sign icons (teal)
- Added distinct blue circle "M" icon for metro/subway stops
- Increased icon sizes across the board for easier touch/click targets
- Terminal stops on line review pages are now larger than intermediate stops

**Metro Stop Support**
- Added `vehicleMode` to the OTP GraphQL stops query, Zod schema, and `Stop` type
- Metro stops now appear from zoom level 12+ (only 85 stops), bus stops remain at 15+

**Map Styles**
- Added map style switcher in Settings: Standard (OSM), Satellite (Esri), Terrain (OpenTopoMap)
- Preference persisted in localStorage
- Tile layer swaps live without reinitializing the map

**Tile Loading**
- Increased `keepBuffer` to 6 (from default 2) to pre-load tiles beyond the viewport
- Set `updateWhenIdle: false` so tiles load during panning, not after
- Set `updateWhenZooming: false` to prevent tile flicker during zoom
- Increased max zoom to 19 for street-level detail

**Bug Fix**
- Fixed popup "Ver todos os horários" button text color to always be white, fixing unreadable text in dark mode

### Files Changed
- `app/api/stations/route.ts` — added `vehicleMode` to GraphQL query
- `lib/schemas/otp.ts` — added `vehicleMode` to Zod schema
- `lib/types.ts` — added `vehicleMode` to Stop interface
- `components/LeafletMap.tsx` — new icons, metro support, map styles, tile buffering
- `components/SettingsModal.tsx` — map style selector UI
- `app/page.tsx` — mapStyle state and persistence
- `app/reviews/line/page.tsx` — bigger stop icons, higher max zoom
- `app/globals.css` — fixed popup link text color
- `lib/translations.ts` — added map style labels (PT + EN)