### PR TITLE
feat: Add Google OAuth sign-in and fix auth modal nesting

### DIFF
--- a/components/FeedbackForm.tsx
+++ b/components/FeedbackForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 import { useTranslations } from "@/lib/hooks/useTranslations";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { AuthModal } from "@/components/AuthModal";
@@ -197,11 +198,12 @@ export function FeedbackForm({
       )}
 
       {/* Auth modal — shown when unauthenticated user tries to submit */}
-      {showAuthModal && (
+      {showAuthModal && createPortal(
         <AuthModal
           onClose={() => setShowAuthModal(false)}
           onSuccess={handleAuthSuccess}
-        />
+        />,
+        document.body
       )}
     </div>
   );

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { useTranslations } from "@/lib/hooks/useTranslations";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { useLocale } from "@/lib/i18n";
@@ -25,14 +26,14 @@ export function SettingsModal({ onClose, onResetOnboarding, mapStyle, onMapStyle
     setIsDark(document.documentElement.classList.contains("dark"));
   }, []);
 
-  // Close on Escape
+  // Close on Escape (but not when AuthModal is open)
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape" && !showAuthModal) onClose();
     };
     document.addEventListener("keydown", handleKey);
     return () => document.removeEventListener("keydown", handleKey);
-  }, [onClose]);
+  }, [onClose, showAuthModal]);
 
   const toggleDarkMode = () => {
     const newValue = !isDark;
@@ -241,11 +242,12 @@ export function SettingsModal({ onClose, onResetOnboarding, mapStyle, onMapStyle
           </div>
         </div>
       </div>
-      {showAuthModal && (
+      {showAuthModal && createPortal(
         <AuthModal
           onClose={() => setShowAuthModal(false)}
           onSuccess={() => setShowAuthModal(false)}
-        />
+        />,
+        document.body
       )}
     </div>
   );

--- a/components/UpvoteButton.tsx
+++ b/components/UpvoteButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { createPortal } from "react-dom";
 import { useTranslations } from "@/lib/hooks/useTranslations";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { AuthModal } from "@/components/AuthModal";
@@ -90,11 +91,12 @@ export function UpvoteButton({ feedbackId, voteCount, userVoted, onVoteChange }:
           {count}
         </span>
       </button>
-      {showAuthModal && (
+      {showAuthModal && createPortal(
         <AuthModal
           onClose={() => setShowAuthModal(false)}
           onSuccess={() => setShowAuthModal(false)}
-        />
+        />,
+        document.body
       )}
     </>
   );

--- a/lib/hooks/useAuth.tsx
+++ b/lib/hooks/useAuth.tsx
@@ -23,6 +23,8 @@ interface AuthContextValue {
   signUp: (email: string, password: string, name: string) => Promise<void>;
   /** Sign in with email + password */
   signIn: (email: string, password: string) => Promise<void>;
+  /** Sign in with a social provider (e.g. Google) */
+  signInSocial: (provider: "google") => Promise<void>;
   /** Clear the session */
   logout: () => Promise<void>;
   /** Send email verification OTP */
@@ -41,6 +43,7 @@ const AuthContext = createContext<AuthContextValue>({
   isAuthenticated: false,
   signUp: async () => {},
   signIn: async () => {},
+  signInSocial: async () => {},
   logout: async () => {},
   sendVerificationOtp: async () => {},
   verifyEmail: async () => {},
@@ -74,6 +77,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       password,
     });
     if (error) throw new Error(error.message ?? "Sign in failed");
+  }, []);
+
+  const signInSocial = useCallback(async (provider: "google") => {
+    const { error } = await authClient.signIn.social({
+      provider,
+      callbackURL: window.location.href,
+    });
+    if (error) throw new Error(error.message ?? "Social sign in failed");
   }, []);
 
   const logout = useCallback(async () => {
@@ -110,13 +121,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       isAuthenticated: !!user,
       signUp,
       signIn,
+      signInSocial,
       logout,
       sendVerificationOtp,
       verifyEmail,
       requestPasswordReset,
       resetPassword,
     }),
-    [user, session.isPending, signUp, signIn, logout, sendVerificationOtp, verifyEmail, requestPasswordReset, resetPassword]
+    [user, session.isPending, signUp, signIn, signInSocial, logout, sendVerificationOtp, verifyEmail, requestPasswordReset, resetPassword]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/lib/translations.ts
+++ b/lib/translations.ts
@@ -252,6 +252,8 @@ const pt = {
     resetSuccess: "Palavra-passe reposta! Pode iniciar sessão.",
     resetError: "Erro ao repor palavra-passe. Tente novamente.",
     backToSignIn: "Voltar ao início de sessão",
+    continueWithGoogle: "Continuar com Google",
+    orDivider: "ou",
   },
 };
 
@@ -507,6 +509,8 @@ const en: typeof pt = {
     resetSuccess: "Password reset! You can now sign in.",
     resetError: "Error resetting password. Try again.",
     backToSignIn: "Back to sign in",
+    continueWithGoogle: "Continue with Google",
+    orDivider: "or",
   },
 };
 


### PR DESCRIPTION
## Summary

Adds Google OAuth as a sign-in option and fixes a bug where the auth modal would close unexpectedly when opened from inside other modals (Settings, FeedbackForm, UpvoteButton).

## Changes

### Google OAuth
- Added "Continue with Google" button to both sign-in and sign-up steps in the AuthModal
- Added `signInSocial` method to `useAuth` hook using `authClient.signIn.social()`
- Added PT/EN translations for the Google button and "or" divider
- Requires Google OAuth to be enabled in the Neon Console (Settings → Auth → OAuth Providers)

### Auth Modal Fix
- **Root cause**: AuthModal was rendered inside parent modals (e.g. SettingsModal at `z-[2000]`), so clicks inside the AuthModal would bubble up to the parent's backdrop `onClick` handler and close everything
- **Fix**: Render AuthModal via `createPortal(…, document.body)` in all 4 components that use it (SettingsModal, FeedbackForm, UpvoteButton, UserMenu)
- Bumped AuthModal z-index to `z-[3000]` to sit above SettingsModal
- SettingsModal's Escape handler now skips when AuthModal is open
- AuthModal's Escape and backdrop click are blocked during social login redirect

## Files changed
- `components/AuthModal.tsx` — Google button UI, higher z-index, backdrop click-outside-to-close
- `components/SettingsModal.tsx` — Portal rendering, Escape guard
- `components/FeedbackForm.tsx` — Portal rendering
- `components/UpvoteButton.tsx` — Portal rendering
- `lib/hooks/useAuth.tsx` — `signInSocial` method
- `lib/translations.ts` — `continueWithGoogle`, `orDivider` (PT + EN)

## Setup required
Enable Google OAuth in the Neon Console → Settings → Auth → OAuth Providers. For localhost development, Neon provides shared credentials that work out of the box.