### PR TITLE
fix: standardize bus destination name casing to title case

### DIFF
--- a/app/api/buses/route.ts
+++ b/app/api/buses/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { getSimulatedBuses } from "@/lib/simulate";
+import { toTitleCase } from "@/lib/strings";
 import {
   FiwareVehiclesResponseSchema,
   type FiwareVehicleEntity,
@@ -317,7 +318,7 @@ export async function GET(request: NextRequest) {
           lat: coords[1],
           lon: coords[0],
           routeShortName: String(routeShortName),
-          routeLongName: String(routeLongName),
+          routeLongName: toTitleCase(String(routeLongName)),
           heading: Number(heading),
           speed: Number(speed),
           lastUpdated: String(lastUpdated),

--- a/app/api/line/route.ts
+++ b/app/api/line/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import polyline from "@mapbox/polyline";
 import { OTPLineResponseSchema } from "@/lib/schemas/otp";
 import { fetchWithRetry, KeyedStaleCache } from "@/lib/api-fetch";
+import { toTitleCase } from "@/lib/strings";
 
 const OTP_URL = "https://otp.portodigital.pt/otp/routers/default/index/graphql";
 
@@ -128,7 +129,7 @@ export async function GET(request: NextRequest) {
     const data = {
       gtfsId: route.gtfsId,
       shortName: route.shortName,
-      longName: route.longName,
+      longName: toTitleCase(route.longName),
       patterns,
       stops: allStops,
     };

--- a/app/api/route-shapes/route.ts
+++ b/app/api/route-shapes/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import polyline from "@mapbox/polyline";
 import { OTPRouteShapesResponseSchema } from "@/lib/schemas/otp";
 import { fetchWithRetry, StaleCache } from "@/lib/api-fetch";
+import { toTitleCase } from "@/lib/strings";
 
 interface PatternGeometry {
   patternId: string;
@@ -103,7 +104,7 @@ export async function GET() {
             allPatterns.push({
               patternId: pattern.id,
               routeShortName: route.shortName,
-              routeLongName: route.longName,
+              routeLongName: toTitleCase(route.longName),
               headsign: pattern.headsign || "",
               directionId: pattern.directionId,
               geometry: {

--- a/app/api/routes/route.ts
+++ b/app/api/routes/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { OTPRoutesSimpleResponseSchema } from "@/lib/schemas/otp";
 import { fetchWithRetry, StaleCache } from "@/lib/api-fetch";
+import { toTitleCase } from "@/lib/strings";
 import type { RouteInfo } from "@/lib/types";
 
 const staleCache = new StaleCache<RouteInfo[]>(24 * 60 * 60 * 1000); // 24 hours
@@ -54,7 +55,7 @@ export async function GET() {
     const routes: RouteInfo[] = validatedRoutes
       .map((r: { shortName: string; longName: string; mode: string; gtfsId: string }) => ({
         shortName: r.shortName,
-        longName: r.longName,
+        longName: toTitleCase(r.longName),
         mode: r.mode as RouteInfo["mode"],
         gtfsId: r.gtfsId,
       }))

--- a/components/CheckInFAB.tsx
+++ b/components/CheckInFAB.tsx
@@ -14,11 +14,6 @@ const MODE_OPTIONS: { mode: TransitMode; emoji: string; key: keyof ReturnType<ty
   { mode: "SCOOTER", emoji: "🛴", key: "scooter" },
 ];
 
-/** Title-case a string (e.g., "BOAVISTA - CAMPANHÃ" → "Boavista - Campanhã") */
-function toTitleCase(s: string): string {
-  return s.replace(/\S+/g, (w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase());
-}
-
 /** Haversine distance in meters between two [lat, lon] points */
 function haversineMeters(lat1: number, lon1: number, lat2: number, lon2: number): number {
   const R = 6371000;
@@ -76,7 +71,7 @@ function findNearbyCandidates(
     for (const bus of buses) {
       const dist = haversineMeters(userLat, userLon, bus.lat, bus.lon);
       if (dist <= MAX_NEARBY_BUS_METRO) {
-        const destination = bus.routeLongName ? ` → ${toTitleCase(bus.routeLongName)}` : "";
+        const destination = bus.routeLongName ? ` → ${bus.routeLongName}` : "";
         const vehicleLabel = bus.vehicleNumber ? ` (#${bus.vehicleNumber})` : "";
         candidates.push({ targetId: bus.id, lat: bus.lat, lon: bus.lon, label: `${t.checkin.bus} ${bus.routeShortName}${vehicleLabel}${destination}`, emoji: "🚌", distance: dist, priority: 0 });
       }

--- a/lib/strings.ts
+++ b/lib/strings.ts
@@ -1,0 +1,7 @@
+/**
+ * Title-case a string, handling accented characters correctly.
+ * e.g., "BOAVISTA - CAMPANHÃ" → "Boavista - Campanhã"
+ */
+export function toTitleCase(s: string): string {
+  return s.replace(/\S+/g, (w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase());
+}


### PR DESCRIPTION
Normalize `routeLongName`/`longName` to title case at the API level so all consumers get consistent casing (e.g., `BOAVISTA - CAMPANHÃ` → `Boavista - Campanhã`).

## Changes
- Created shared `toTitleCase` utility in `lib/strings.ts`
- Applied at API level in `/api/buses`, `/api/routes`, `/api/route-shapes`, `/api/line`
- Removed client-side `toTitleCase` from `CheckInFAB.tsx` (no longer needed)

Closes #57