### PR TITLE
fix: quantize user GPS coordinates to ~100m for non-infrastructure check-ins

### DIFF
--- a/components/CheckInFAB.tsx
+++ b/components/CheckInFAB.tsx
@@ -227,7 +227,7 @@ export function CheckInFAB({ userLocation, buses = [], stops = [], bikeParks = [
   }, [activeCheckIn, minutesLeft, isAuthenticated]);
 
   // Check-in handler — works for both anonymous and authenticated users
-  // lat/lon are target infrastructure coordinates (bus stop, bike park), NOT user GPS
+  // lat/lon are target infrastructure coordinates or user GPS (quantized server-side to ~100m)
   const handleCheckIn = useCallback(async (mode: TransitMode, targetId?: string, targetLat?: number, targetLon?: number) => {
     // Block if anon user already has an active check-in (client-side guard)
     if (!isAuthenticated && activeCheckIn) {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,7 +79,7 @@ model CheckIn {
   user      User?       @relation(fields: [userId], references: [id], onDelete: Cascade)
   mode      TransitMode
   targetId  String?     // optional: line shortName ("205"), metro line ("D")
-  lat       Float?      // target location (infrastructure), not user GPS
+  lat       Float?      // location: infrastructure coords or quantized (~100m) user GPS
   lon       Float?
   anonHash  String?     // truncated hash of IP+UA for anonymous rate limiting (not PII)
   createdAt DateTime    @default(now())


### PR DESCRIPTION
## Problem

The check-in API comments claimed lat/lon were always "target infrastructure coordinates, NOT user GPS", but for `bike-here`, `walk`, and `scooter` check-ins, the user's exact GPS coordinates were being stored in the database.

## Fix

- Quantize coordinates to 3 decimal places (~100m precision) server-side for non-infrastructure check-ins (`bike-here`, `walk`, `scooter`, or no targetId)
- Infrastructure check-ins (bus stops, bike parks, bike lanes) keep full precision since those are public fixed locations
- Updated misleading comments in `prisma/schema.prisma`, `app/api/checkin/route.ts`, and `components/CheckInFAB.tsx`