### PR TITLE
fix: stop storing user GPS for bike-here/walk/scooter check-ins

### DIFF
--- a/app/api/checkin/route.ts
+++ b/app/api/checkin/route.ts
@@ -51,7 +51,7 @@ function anonFingerprint(request: NextRequest): string {
 // Authenticated: replaces existing check-in, 1h TTL, linked to user
 // Anonymous: 30min TTL, rate limited by IP hash, no userId stored
 // Body: { mode: "BUS", targetId?: "205", lat?: number, lon?: number }
-// lat/lon: infrastructure coords for stops/parks, or quantized (~100m) user GPS for bike-here/walk/scooter
+// lat/lon: infrastructure coords for stops/parks; null for bike-here/walk/scooter (privacy)
 export async function POST(request: NextRequest) {
   // CSRF protection
   const csrfError = validateOrigin(request);
@@ -84,15 +84,8 @@ export async function POST(request: NextRequest) {
   }
 
   // Validate optional lat/lon (target infrastructure coordinates)
-  const rawLat = typeof lat === "number" && lat >= -90 && lat <= 90 ? lat : null;
-  const rawLon = typeof lon === "number" && lon >= -180 && lon <= 180 ? lon : null;
-
-  // Privacy: quantize coordinates to ~100m precision (3 decimal places) for
-  // non-infrastructure check-ins (bike-here, walk, scooter) where lat/lon
-  // represents the user's actual GPS position rather than a fixed stop/park.
-  const isUserLocation = !targetId || targetId === "bike-here" || targetId === "walk" || targetId === "scooter";
-  const checkinLat = rawLat !== null && isUserLocation ? Math.round(rawLat * 1000) / 1000 : rawLat;
-  const checkinLon = rawLon !== null && isUserLocation ? Math.round(rawLon * 1000) / 1000 : rawLon;
+  const checkinLat = typeof lat === "number" && lat >= -90 && lat <= 90 ? lat : null;
+  const checkinLon = typeof lon === "number" && lon >= -180 && lon <= 180 ? lon : null;
 
   // Anti-spoofing: reject coordinates outside Porto metropolitan area
   if (checkinLat !== null && checkinLon !== null && !isWithinPortoBounds(checkinLat, checkinLon)) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -293,8 +293,8 @@ function MapPageContent() {
           if (action === "add") {
             if (idx >= 0) {
               checkIns[idx] = { ...checkIns[idx], count: checkIns[idx].count + 1 };
-            } else if (detail.lat != null && detail.lon != null) {
-              checkIns.push({ mode: detail.mode, targetId: detail.targetId || "", lat: detail.lat, lon: detail.lon, count: 1 });
+            } else {
+              checkIns.push({ mode: detail.mode, targetId: detail.targetId || "", lat: detail.lat ?? null, lon: detail.lon ?? null, count: 1 });
             }
             return { ...base, checkIns, total: base.total + 1, todayTotal: base.todayTotal + 1 };
           } else {

--- a/components/CheckInFAB.tsx
+++ b/components/CheckInFAB.tsx
@@ -128,10 +128,11 @@ function findNearbyCandidates(
       }
     }
     // Always offer "cycling here" at user's location — signals demand for bike infrastructure
-    candidates.push({ targetId: "bike-here", lat: userLat, lon: userLon, label: t.checkin.cyclingHere, emoji: "🚲", distance: 0, priority: 2 });
+    // lat/lon NOT sent to API (privacy) — shown client-side only via userLocation prop
+    candidates.push({ targetId: "bike-here", lat: 0, lon: 0, label: t.checkin.cyclingHere, emoji: "🚲", distance: 0, priority: 2 });
   } else {
-    // WALK / SCOOTER — user location directly
-    return [{ targetId: mode.toLowerCase(), lat: userLat, lon: userLon, label: "", emoji: mode === "WALK" ? "🚶" : "🛴", distance: 0, priority: 0 }];
+    // WALK / SCOOTER — no lat/lon sent to API (privacy) — shown client-side only
+    return [{ targetId: mode.toLowerCase(), lat: 0, lon: 0, label: "", emoji: mode === "WALK" ? "🚶" : "🛴", distance: 0, priority: 0 }];
   }
 
   // Sort by priority first (live/primary before static/fallback), then by distance
@@ -331,10 +332,10 @@ export function CheckInFAB({ userLocation, buses = [], stops = [], bikeParks = [
       return;
     }
 
-    // WALK/SCOOTER: auto-pick (user location, no infrastructure to disambiguate)
+    // WALK/SCOOTER: auto-pick — no lat/lon sent to API (privacy)
     if (mode === "WALK" || mode === "SCOOTER") {
       const best = candidates[0];
-      handleCheckIn(mode, best.targetId, best.lat, best.lon);
+      handleCheckIn(mode, best.targetId, undefined, undefined);
       return;
     }
 
@@ -444,7 +445,11 @@ export function CheckInFAB({ userLocation, buses = [], stops = [], bikeParks = [
                 {nearbyCandidates.map((c, i) => (
                   <button
                     key={`${c.targetId}-${i}`}
-                    onClick={() => handleCheckIn(selectedMode, c.targetId, c.lat, c.lon)}
+                    onClick={() => {
+                      // Don't send lat/lon for user-location check-ins (privacy)
+                      const isUserLoc = c.targetId === "bike-here" || c.targetId === "walk" || c.targetId === "scooter";
+                      handleCheckIn(selectedMode, c.targetId, isUserLoc ? undefined : c.lat, isUserLoc ? undefined : c.lon);
+                    }}
                     disabled={isLoading}
                     className="flex items-center gap-3 px-3 py-2 rounded-xl hover:bg-surface-sunken transition-colors text-left disabled:opacity-50"
                   >

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -222,8 +222,8 @@ export interface CheckInItem {
 export interface ActiveCheckIn {
   mode: TransitMode;
   targetId: string | null;
-  lat: number;
-  lon: number;
+  lat: number | null;
+  lon: number | null;
   count: number;
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,7 +79,7 @@ model CheckIn {
   user      User?       @relation(fields: [userId], references: [id], onDelete: Cascade)
   mode      TransitMode
   targetId  String?     // optional: line shortName ("205"), metro line ("D")
-  lat       Float?      // location: infrastructure coords or quantized (~100m) user GPS
+  lat       Float?      // infrastructure coords (bus stop, bike park); null for user-location check-ins
   lon       Float?
   anonHash  String?     // truncated hash of IP+UA for anonymous rate limiting (not PII)
   createdAt DateTime    @default(now())


### PR DESCRIPTION
## Problem

The `bike-here`, `walk`, and `scooter` check-ins were storing the user's actual GPS coordinates in the database. Even with the quantization from PR #61, this is unnecessary — the map can show these activity markers using the client-side `userLocation` prop without ever persisting user location.

## Changes

- **CheckInFAB**: No longer sends lat/lon to the API for user-location check-ins (`bike-here`, `walk`, `scooter`)
- **API route**: Removed quantization code; simple validation only. These check-ins now have `null` lat/lon in the DB.
- **Active endpoint**: Returns check-ins without lat/lon too (removed `IS NOT NULL` filter) so we still get activity counts
- **ActivityBubbles**: Resolves missing coords from the `userLocation` prop — markers appear at the user's current position client-side only (ephemeral, never persisted)
- **Types**: `ActiveCheckIn.lat`/`lon` are now nullable
- **Schema**: Updated comments to reflect the privacy model

## Privacy model

| Check-in type | lat/lon stored | Map display |
|---|---|---|
| Bus stop, metro stop | Infrastructure coords (public) | From DB |
| Bike park | Infrastructure coords (public) | From DB |
| Bike lane | Infrastructure coords (public) | From DB |
| Cycling here | null | Client-side userLocation |
| Walk | null | Client-side userLocation |
| Scooter | null | Client-side userLocation |