### PR TITLE
chore: upgrade TypeScript to 6.0

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -16,6 +16,6 @@ primary_region = 'cdg'
 
 [[vm]]
   size = 'shared-cpu-1x'
-  memory = '512mb'
+  memory = '1gb'
   cpus = 1
-  memory_mb = 512
+  memory_mb = 1024

--- a/fly.toml
+++ b/fly.toml
@@ -16,5 +16,5 @@ primary_region = 'cdg'
 
 [[vm]]
   size = 'shared-cpu-1x'
-  memory = '256mb'
+  memory = '512mb'
   cpus = 1

--- a/fly.toml
+++ b/fly.toml
@@ -16,6 +16,5 @@ primary_region = 'cdg'
 
 [[vm]]
   size = 'shared-cpu-1x'
-  memory = '1gb'
+  memory = '256mb'
   cpus = 1
-  memory_mb = 1024

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "prettier": "^3.8.1",
     "prisma": "^7.4.2",
     "tailwindcss": "^4.2.1",
-    "typescript": "^5",
+    "typescript": "^6.0.0",
     "vitest": "^4.0.18"
   },
   "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
         version: 1.2.1
       '@neondatabase/auth':
         specifier: 0.2.0-beta.1
-        version: 0.2.0-beta.1(aehyzkj67jxi5ax6lrhclyl4du)
+        version: 0.2.0-beta.1(pajjgmo7di34l36p2qi2ic7wpm)
       '@neondatabase/serverless':
         specifier: ^1.0.2
         version: 1.0.2
@@ -39,7 +39,7 @@ importers:
         version: 7.4.2
       '@prisma/client':
         specifier: ^7.4.2
-        version: 7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2)
       dotenv:
         specifier: ^17.3.1
         version: 17.3.1
@@ -103,7 +103,7 @@ importers:
         version: 9.39.2(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.1.6
-        version: 16.1.6(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.1.6(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
         version: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -112,7 +112,7 @@ importers:
         version: 9.1.7
       knip:
         specifier: ^5.85.0
-        version: 5.85.0(@types/node@25.3.3)(typescript@5.9.3)
+        version: 5.85.0(@types/node@25.3.3)(typescript@6.0.2)
       lint-staged:
         specifier: ^16.3.2
         version: 16.3.2
@@ -124,13 +124,13 @@ importers:
         version: 3.8.1
       prisma:
         specifier: ^7.4.2
-        version: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+        version: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)
       tailwindcss:
         specifier: ^4.2.1
         version: 4.2.1
       typescript:
-        specifier: ^5
-        version: 5.9.3
+        specifier: ^6.0.0
+        version: 6.0.2
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -6075,8 +6075,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -7640,14 +7640,14 @@ snapshots:
       '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/passkey@1.4.18(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)':
+  '@better-auth/passkey@1.4.18(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)':
     dependencies:
       '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@simplewebauthn/browser': 13.2.2
       '@simplewebauthn/server': 13.2.3
-      better-auth: 1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      better-auth: 1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       better-call: 1.3.2(zod@4.3.6)
       nanostores: 1.1.1
       zod: 4.3.6
@@ -7685,20 +7685,20 @@ snapshots:
 
   '@chevrotain/utils@10.5.0': {}
 
-  '@daveyplate/better-auth-tanstack@1.3.6(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(better-auth@1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@daveyplate/better-auth-tanstack@1.3.6(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(better-auth@1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@tanstack/query-core': 5.90.20
       '@tanstack/react-query': 5.90.21(react@19.2.4)
-      better-auth: 1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      better-auth: 1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@daveyplate/better-auth-ui@3.3.9(sweajfz5kysgunwzvufmpmeo2y)':
+  '@daveyplate/better-auth-ui@3.3.9(bjmqo5tyn6k5ykp4yxdgnovhdu)':
     dependencies:
-      '@better-auth/passkey': 1.4.18(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
+      '@better-auth/passkey': 1.4.18(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
       '@better-fetch/fetch': 1.1.21
       '@captchafox/react': 1.10.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@daveyplate/better-auth-tanstack': 1.3.6(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(better-auth@1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@daveyplate/better-auth-tanstack': 1.3.6(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(better-auth@1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@hcaptcha/react-hcaptcha': 1.17.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@hookform/resolvers': 5.2.2(react-hook-form@7.71.1(react@19.2.4))
       '@instantdb/react': 0.22.138(react@19.2.4)
@@ -7719,10 +7719,10 @@ snapshots:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@react-email/components': 1.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-query': 5.90.21(react@19.2.4)
-      '@triplit/client': 1.0.50(typescript@5.9.3)
-      '@triplit/react': 1.0.51(react@19.2.4)(typescript@5.9.3)
+      '@triplit/client': 1.0.50(typescript@6.0.2)
+      '@triplit/react': 1.0.51(react@19.2.4)(typescript@6.0.2)
       '@wojtekmaj/react-recaptcha-v3': 0.1.4(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      better-auth: 1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      better-auth: 1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       class-variance-authority: 0.7.1
       clsx: 2.1.1
       input-otp: 1.4.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -8246,14 +8246,14 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@neondatabase/auth-ui@0.1.0-alpha.11(wzlt2jxmezzfsbawek6tsr5ybi)':
+  '@neondatabase/auth-ui@0.1.0-alpha.11(n375uos4s7jx75bqzbxiucfg5e)':
     dependencies:
       '@captchafox/react': 1.10.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@daveyplate/better-auth-ui': 3.3.9(sweajfz5kysgunwzvufmpmeo2y)
+      '@daveyplate/better-auth-ui': 3.3.9(bjmqo5tyn6k5ykp4yxdgnovhdu)
       '@hcaptcha/react-hcaptcha': 1.17.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@hookform/resolvers': 5.2.2(react-hook-form@7.71.1(react@19.2.4))
       '@marsidev/react-turnstile': 1.4.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@neondatabase/auth': 0.2.0-beta.1(aehyzkj67jxi5ax6lrhclyl4du)
+      '@neondatabase/auth': 0.2.0-beta.1(pajjgmo7di34l36p2qi2ic7wpm)
       '@radix-ui/react-avatar': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-context': 1.1.3(@types/react@19.2.14)(react@19.2.4)
@@ -8296,11 +8296,11 @@ snapshots:
       - '@types/react-dom'
       - better-auth
 
-  '@neondatabase/auth@0.2.0-beta.1(aehyzkj67jxi5ax6lrhclyl4du)':
+  '@neondatabase/auth@0.2.0-beta.1(pajjgmo7di34l36p2qi2ic7wpm)':
     dependencies:
-      '@neondatabase/auth-ui': 0.1.0-alpha.11(wzlt2jxmezzfsbawek6tsr5ybi)
+      '@neondatabase/auth-ui': 0.1.0-alpha.11(n375uos4s7jx75bqzbxiucfg5e)
       '@supabase/auth-js': 2.79.0
-      better-auth: 1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      better-auth: 1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       jose: 6.1.2
       zod: 4.1.12
     optionalDependencies:
@@ -8560,12 +8560,12 @@ snapshots:
 
   '@prisma/client-runtime-utils@7.4.2': {}
 
-  '@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)':
+  '@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2)':
     dependencies:
       '@prisma/client-runtime-utils': 7.4.2
     optionalDependencies:
-      prisma: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      typescript: 5.9.3
+      prisma: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)
+      typescript: 6.0.2
 
   '@prisma/config@7.4.2':
     dependencies:
@@ -8580,7 +8580,7 @@ snapshots:
 
   '@prisma/debug@7.4.2': {}
 
-  '@prisma/dev@0.20.0(typescript@5.9.3)':
+  '@prisma/dev@0.20.0(typescript@6.0.2)':
     dependencies:
       '@electric-sql/pglite': 0.3.15
       '@electric-sql/pglite-socket': 0.0.20(@electric-sql/pglite@0.3.15)
@@ -8597,7 +8597,7 @@ snapshots:
       proper-lockfile: 4.1.2
       remeda: 2.33.4
       std-env: 3.10.0
-      valibot: 1.2.0(typescript@5.9.3)
+      valibot: 1.2.0(typescript@6.0.2)
       zeptomatch: 2.1.0
     transitivePeerDependencies:
       - typescript
@@ -9819,10 +9819,10 @@ snapshots:
       '@tanstack/query-core': 5.90.20
       react: 19.2.4
 
-  '@triplit/client@1.0.50(typescript@5.9.3)':
+  '@triplit/client@1.0.50(typescript@6.0.2)':
     dependencies:
-      '@triplit/db': 1.1.10(typescript@5.9.3)
-      '@triplit/logger': 0.0.3(typescript@5.9.3)
+      '@triplit/db': 1.1.10(typescript@6.0.2)
+      '@triplit/logger': 0.0.3(typescript@6.0.2)
       comlink: 4.4.2
       superjson: 2.2.6
     transitivePeerDependencies:
@@ -9832,9 +9832,9 @@ snapshots:
       - typescript
       - uuidv7
 
-  '@triplit/db@1.1.10(typescript@5.9.3)':
+  '@triplit/db@1.1.10(typescript@6.0.2)':
     dependencies:
-      '@triplit/logger': 0.0.3(typescript@5.9.3)
+      '@triplit/logger': 0.0.3(typescript@6.0.2)
       core-js: 3.48.0
       elen: 1.0.10
       nanoid: 5.1.6
@@ -9843,13 +9843,13 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@triplit/logger@0.0.3(typescript@5.9.3)':
+  '@triplit/logger@0.0.3(typescript@6.0.2)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
-  '@triplit/react@1.0.51(react@19.2.4)(typescript@5.9.3)':
+  '@triplit/react@1.0.51(react@19.2.4)(typescript@6.0.2)':
     dependencies:
-      '@triplit/client': 1.0.50(typescript@5.9.3)
+      '@triplit/client': 1.0.50(typescript@6.0.2)
       react: 19.2.4
     transitivePeerDependencies:
       - better-sqlite3
@@ -9950,40 +9950,40 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
-  '@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
       '@typescript-eslint/scope-manager': 8.55.0
-      '@typescript-eslint/type-utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.55.0
       eslint: 9.39.2(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.4.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.55.0
       '@typescript-eslint/types': 8.55.0
-      '@typescript-eslint/typescript-estree': 8.55.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.55.0(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.55.0
       debug: 4.4.3
       eslint: 9.39.2(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.55.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.55.0(typescript@6.0.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.55.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.55.0(typescript@6.0.2)
       '@typescript-eslint/types': 8.55.0
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -9992,47 +9992,47 @@ snapshots:
       '@typescript-eslint/types': 8.55.0
       '@typescript-eslint/visitor-keys': 8.55.0
 
-  '@typescript-eslint/tsconfig-utils@8.55.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.55.0(typescript@6.0.2)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
-  '@typescript-eslint/type-utils@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/types': 8.55.0
-      '@typescript-eslint/typescript-estree': 8.55.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.55.0(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
       debug: 4.4.3
       eslint: 9.39.2(jiti@2.6.1)
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.4.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.55.0': {}
 
-  '@typescript-eslint/typescript-estree@8.55.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.55.0(typescript@6.0.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.55.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.55.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.55.0(typescript@6.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.55.0(typescript@6.0.2)
       '@typescript-eslint/types': 8.55.0
       '@typescript-eslint/visitor-keys': 8.55.0
       debug: 4.4.3
       minimatch: 10.2.4
       semver: 7.7.4
       tinyglobby: 0.2.15
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.4.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.55.0
       '@typescript-eslint/types': 8.55.0
-      '@typescript-eslint/typescript-estree': 8.55.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.55.0(typescript@6.0.2)
       eslint: 9.39.2(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -10431,7 +10431,7 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
-  better-auth@1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  better-auth@1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/kysely-adapter': 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)
@@ -10448,10 +10448,10 @@ snapshots:
       nanostores: 1.1.1
       zod: 4.3.6
     optionalDependencies:
-      '@prisma/client': 7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
+      '@prisma/client': 7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2)
       mysql2: 3.15.3
       next: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      prisma: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      prisma: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       vitest: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -10944,20 +10944,20 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.1.6(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-next@16.1.6(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2):
     dependencies:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
       globals: 16.4.0
-      typescript-eslint: 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      typescript-eslint: 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-webpack
@@ -10983,22 +10983,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11009,7 +11009,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11021,7 +11021,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -11769,7 +11769,7 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  knip@5.85.0(@types/node@25.3.3)(typescript@5.9.3):
+  knip@5.85.0(@types/node@25.3.3)(typescript@6.0.2):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
       '@types/node': 25.3.3
@@ -11783,7 +11783,7 @@ snapshots:
       picomatch: 4.0.3
       smol-toml: 1.6.0
       strip-json-comments: 5.0.3
-      typescript: 5.9.3
+      typescript: 6.0.2
       zod: 4.3.6
 
   kysely@0.28.11: {}
@@ -12318,16 +12318,16 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
-  prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
+  prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2):
     dependencies:
       '@prisma/config': 7.4.2
-      '@prisma/dev': 0.20.0(typescript@5.9.3)
+      '@prisma/dev': 0.20.0(typescript@6.0.2)
       '@prisma/engines': 7.4.2
       '@prisma/studio-core': 0.13.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       mysql2: 3.15.3
       postgres: 3.4.7
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - '@types/react'
       - magicast
@@ -12982,9 +12982,9 @@ snapshots:
 
   trim-newlines@3.0.1: {}
 
-  ts-api-utils@2.4.0(typescript@5.9.3):
+  ts-api-utils@2.4.0(typescript@6.0.2):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -13068,18 +13068,18 @@ snapshots:
       tunnel: 0.0.6
       underscore: 1.13.8
 
-  typescript-eslint@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.55.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/typescript-estree': 8.55.0(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
       eslint: 9.39.2(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   ua-is-frozen@0.1.2: {}
 
@@ -13178,9 +13178,9 @@ snapshots:
 
   uuid@11.1.0: {}
 
-  valibot@1.2.0(typescript@5.9.3):
+  valibot@1.2.0(typescript@6.0.2):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,8 @@
     "paths": {
       "@/*": ["./*"]
     },
-    "target": "ES2023"
+    "target": "ES2023",
+    "types": ["node"]
   },
   "include": [
     "next-env.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,8 @@
       "@/*": ["./*"]
     },
     "target": "ES2023",
-    "types": ["node"]
+    "types": ["node"],
+    "noUncheckedSideEffectImports": false
   },
   "include": [
     "next-env.d.ts",

--- a/worker/cron_aggregate.go
+++ b/worker/cron_aggregate.go
@@ -46,12 +46,25 @@ func listSnapshotKeys(ctx context.Context, r2 *s3.Client, bucket, dateStr string
 }
 
 func runAggregateDaily(ctx context.Context, pool *pgxpool.Pool, r2 *s3.Client, bucket string) error {
+	return runAggregateDailyWithDate(ctx, pool, r2, bucket, time.Time{})
+}
+
+func runAggregateDailyWithDate(ctx context.Context, pool *pgxpool.Pool, r2 *s3.Client, bucket string, overrideDate time.Time) error {
 	startTime := time.Now()
 
 	now := time.Now().UTC()
-	yesterday := time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.UTC)
-	today := yesterday.AddDate(0, 0, 1)
-	dateStr := yesterday.Format("2006-01-02")
+	var yesterday, today time.Time
+	var dateStr string
+
+	if !overrideDate.IsZero() {
+		yesterday = time.Date(overrideDate.Year(), overrideDate.Month(), overrideDate.Day(), 0, 0, 0, 0, time.UTC)
+		today = yesterday.AddDate(0, 0, 1)
+		dateStr = yesterday.Format("2006-01-02")
+	} else {
+		yesterday = time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.UTC)
+		today = yesterday.AddDate(0, 0, 1)
+		dateStr = yesterday.Format("2006-01-02")
+	}
 
 	log.Printf("[aggregate] Starting for %s", dateStr)
 

--- a/worker/cron_aggregate_incremental.go
+++ b/worker/cron_aggregate_incremental.go
@@ -1,0 +1,733 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const snapshotBatchSize = 500
+
+func runAggregateDailyIncremental(ctx context.Context, pool *pgxpool.Pool, r2 *s3.Client, bucket string, overrideDate time.Time) error {
+	startTime := time.Now()
+
+	now := time.Now().UTC()
+	var yesterday, today time.Time
+	var dateStr string
+
+	if !overrideDate.IsZero() {
+		yesterday = time.Date(overrideDate.Year(), overrideDate.Month(), overrideDate.Day(), 0, 0, 0, 0, time.UTC)
+		today = yesterday.AddDate(0, 0, 1)
+		dateStr = yesterday.Format("2006-01-02")
+	} else {
+		yesterday = time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.UTC)
+		today = yesterday.AddDate(0, 0, 1)
+		dateStr = yesterday.Format("2006-01-02")
+	}
+
+	log.Printf("[aggregate] Starting incremental aggregation for %s", dateStr)
+
+	// Create temporary staging table for positions
+	_, err := pool.Exec(ctx, `
+		CREATE UNLOGGED TABLE IF NOT EXISTS "PositionStagingTemp" (
+			id BIGSERIAL PRIMARY KEY,
+			"recordedAt" TIMESTAMPTZ NOT NULL,
+			"vehicleId" TEXT NOT NULL,
+			"vehicleNum" TEXT,
+			route TEXT NOT NULL,
+			"directionId" SMALLINT,
+			lat DOUBLE PRECISION NOT NULL,
+			lon DOUBLE PRECISION NOT NULL,
+			speed REAL,
+			"tripId" TEXT
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("create staging table: %w", err)
+	}
+	defer pool.Exec(ctx, `DROP TABLE IF EXISTS "PositionStagingTemp"`)
+
+	// Clear staging table
+	_, err = pool.Exec(ctx, `TRUNCATE TABLE "PositionStagingTemp"`)
+	if err != nil {
+		return fmt.Errorf("truncate staging: %w", err)
+	}
+
+	// List snapshot files
+	keys, err := listSnapshotKeys(ctx, r2, bucket, dateStr)
+	if err != nil {
+		return fmt.Errorf("list snapshots: %w", err)
+	}
+	if len(keys) == 0 {
+		log.Printf("[aggregate] No snapshots found for %s", dateStr)
+		return nil
+	}
+	log.Printf("[aggregate] Found %d snapshot files", len(keys))
+
+	// Pre-load segments
+	segRows, err := pool.Query(ctx, `SELECT id, route, "directionId", "segmentIndex", "startLat", "startLon", "endLat", "endLon", "midLat", "midLon", "lengthM", geometry FROM "RouteSegment"`)
+	if err != nil {
+		return fmt.Errorf("load segments: %w", err)
+	}
+	var segDefs []SegmentDef
+	for segRows.Next() {
+		var s SegmentDef
+		var geomJSON []byte
+		err := segRows.Scan(&s.ID, &s.Route, &s.DirectionID, &s.SegmentIndex,
+			&s.StartLat, &s.StartLon, &s.EndLat, &s.EndLon,
+			&s.MidLat, &s.MidLon, &s.LengthM, &geomJSON)
+		if err != nil {
+			segRows.Close()
+			return fmt.Errorf("scan segment: %w", err)
+		}
+		json.Unmarshal(geomJSON, &s.Geometry)
+		segDefs = append(segDefs, s)
+	}
+	segRows.Close()
+
+	// Pre-load route stops
+	type routeStop struct {
+		Route       string
+		DirectionID int
+		StopSeq     int
+		StopID      string
+		StopName    *string
+		Lat         float64
+		Lon         float64
+	}
+	stopsByRoute := make(map[string][]routeStop)
+	rsRows, err := pool.Query(ctx, `SELECT route, "directionId", "stopSequence", "stopId", "stopName", lat, lon FROM "RouteStop"`)
+	if err != nil {
+		return fmt.Errorf("load route stops: %w", err)
+	}
+	for rsRows.Next() {
+		var rs routeStop
+		if err := rsRows.Scan(&rs.Route, &rs.DirectionID, &rs.StopSeq, &rs.StopID, &rs.StopName, &rs.Lat, &rs.Lon); err != nil {
+			rsRows.Close()
+			return fmt.Errorf("scan route stop: %w", err)
+		}
+		stopsByRoute[rs.Route] = append(stopsByRoute[rs.Route], rs)
+	}
+	rsRows.Close()
+
+	// Process snapshots in batches
+	var totalPositions int64
+	hourlySegmentSpeeds := make(map[string][]float64)
+	stopArrivals := make(map[string][]int64)
+	lastSeenAt := make(map[string]int64)
+
+	batchNum := 0
+	for batchStart := 0; batchStart < len(keys); batchStart += snapshotBatchSize {
+		batchEnd := batchStart + snapshotBatchSize
+		if batchEnd > len(keys) {
+			batchEnd = len(keys)
+		}
+		batchNum++
+
+		// Process each snapshot in this batch
+		var batchPositions []PositionPoint
+		for _, key := range keys[batchStart:batchEnd] {
+			out, err := r2.GetObject(ctx, &s3.GetObjectInput{Bucket: &bucket, Key: &key})
+			if err != nil {
+				log.Printf("[aggregate] WARNING: failed to fetch %s: %v", key, err)
+				continue
+			}
+			body, err := io.ReadAll(out.Body)
+			out.Body.Close()
+			if err != nil {
+				log.Printf("[aggregate] WARNING: failed to read %s: %v", key, err)
+				continue
+			}
+
+			var snap SnapshotFile
+			if err := json.Unmarshal(body, &snap); err != nil {
+				log.Printf("[aggregate] WARNING: failed to parse %s: %v", key, err)
+				continue
+			}
+
+			recordedAt, err := time.Parse(time.RFC3339, snap.RecordedAt)
+			if err != nil {
+				continue
+			}
+
+			for _, p := range snap.Positions {
+				if p.Route == "" {
+					continue
+				}
+				pp := PositionPoint{
+					RecordedAt: recordedAt,
+					VehicleID:  p.VehicleID,
+					Route:      p.Route,
+					Lat:        p.Lat,
+					Lon:        p.Lon,
+					Speed:      p.Speed,
+				}
+				if p.VehicleNum != "" {
+					pp.VehicleNum = &p.VehicleNum
+				}
+				if p.TripID != "" {
+					pp.TripID = &p.TripID
+				}
+				pp.DirectionID = p.DirectionID
+
+				batchPositions = append(batchPositions, pp)
+
+				// Segment speeds (keep in memory - small)
+				if pp.Speed != nil && *pp.Speed > 0 && len(segDefs) > 0 {
+					segID := snapToSegment(pp.Lat, pp.Lon, pp.Route, pp.DirectionID, segDefs, 150)
+					if segID != "" {
+						hour := time.Date(pp.RecordedAt.Year(), pp.RecordedAt.Month(), pp.RecordedAt.Day(), pp.RecordedAt.Hour(), 0, 0, 0, time.UTC)
+						key := segID + ":" + hour.Format(time.RFC3339)
+						hourlySegmentSpeeds[key] = append(hourlySegmentSpeeds[key], float64(*pp.Speed))
+					}
+				}
+
+				// Stop arrivals (keep in memory - small)
+				stopsForRoute := stopsByRoute[pp.Route]
+				if len(stopsForRoute) > 0 {
+					var bestStop *routeStop
+					bestDist := math.Inf(1)
+					for i := range stopsForRoute {
+						rs := &stopsForRoute[i]
+						if pp.DirectionID != nil && rs.DirectionID != int(*pp.DirectionID) {
+							continue
+						}
+						dist := haversineM(pp.Lat, pp.Lon, rs.Lat, rs.Lon)
+						if dist < bestDist && dist <= 80 {
+							bestDist = dist
+							bestStop = rs
+						}
+					}
+					if bestStop != nil {
+						dirStr := "x"
+						if pp.DirectionID != nil {
+							dirStr = fmt.Sprintf("%d", *pp.DirectionID)
+						}
+						stopKey := pp.Route + ":" + dirStr + ":" + bestStop.StopID
+						dedupeKey := pp.VehicleID + ":" + stopKey
+						ts := pp.RecordedAt.UnixMilli()
+						last, exists := lastSeenAt[dedupeKey]
+						if !exists || ts-last >= 3*60*1000 {
+							lastSeenAt[dedupeKey] = ts
+							stopArrivals[stopKey] = append(stopArrivals[stopKey], ts)
+						}
+					}
+				}
+
+				totalPositions++
+			}
+
+			// Free memory immediately
+			body = nil
+			snap.Positions = nil
+		}
+
+		// Write batch positions to staging table
+		if len(batchPositions) > 0 {
+			for i := 0; i < len(batchPositions); i += 1000 {
+				end := i + 1000
+				if end > len(batchPositions) {
+					end = len(batchPositions)
+				}
+				chunk := batchPositions[i:end]
+
+				query := `INSERT INTO "PositionStagingTemp" ("recordedAt", "vehicleId", "vehicleNum", route, "directionId", lat, lon, speed, "tripId") VALUES `
+				var args []interface{}
+				var placeholders []string
+				for j, p := range chunk {
+					base := j * 9
+					placeholders = append(placeholders, fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)",
+						base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8, base+9))
+					args = append(args, p.RecordedAt, p.VehicleID, p.VehicleNum, p.Route, p.DirectionID, p.Lat, p.Lon, p.Speed, p.TripID)
+				}
+				query += strings.Join(placeholders, ",")
+				if _, err := pool.Exec(ctx, query, args...); err != nil {
+					return fmt.Errorf("insert positions batch: %w", err)
+				}
+			}
+		}
+
+		log.Printf("[aggregate] Batch %d/%d: %d positions loaded", batchNum, (len(keys)+snapshotBatchSize-1)/snapshotBatchSize, len(batchPositions))
+
+		// Clear batch positions to free memory
+		batchPositions = nil
+	}
+
+	log.Printf("[aggregate] Processed %d positions from %d files in %d batches", totalPositions, len(keys), batchNum)
+
+	// Trip reconstruction from staging table (stream by vehicle)
+	log.Printf("[aggregate] Reconstructing trips from staging table...")
+
+	// Get all unique vehicles
+	vehicleRows, err := pool.Query(ctx, `SELECT DISTINCT "vehicleId" FROM "PositionStagingTemp" ORDER BY "vehicleId"`)
+	if err != nil {
+		return fmt.Errorf("get vehicles: %w", err)
+	}
+	var vehicles []string
+	for vehicleRows.Next() {
+		var v string
+		if err := vehicleRows.Scan(&v); err != nil {
+			vehicleRows.Close()
+			return fmt.Errorf("scan vehicle: %w", err)
+		}
+		vehicles = append(vehicles, v)
+	}
+	vehicleRows.Close()
+
+	var allTrips []ReconstructedTrip
+	processedVehicles := 0
+
+	// Process vehicles in batches of 50 to avoid loading all at once
+	for batchStart := 0; batchStart < len(vehicles); batchStart += 50 {
+		batchEnd := batchStart + 50
+		if batchEnd > len(vehicles) {
+			batchEnd = len(vehicles)
+		}
+
+		for _, vehicleID := range vehicles[batchStart:batchEnd] {
+			// Stream positions for this vehicle from staging table
+			posRows, err := pool.Query(ctx, `
+				SELECT "recordedAt", "vehicleId", "vehicleNum", route, "directionId", lat, lon, speed, "tripId"
+				FROM "PositionStagingTemp"
+				WHERE "vehicleId" = $1
+				ORDER BY "recordedAt"
+			`, vehicleID)
+			if err != nil {
+				return fmt.Errorf("get positions for vehicle %s: %w", vehicleID, err)
+			}
+
+			var positions []PositionPoint
+			for posRows.Next() {
+				var p PositionPoint
+				if err := posRows.Scan(&p.RecordedAt, &p.VehicleID, &p.VehicleNum, &p.Route, &p.DirectionID, &p.Lat, &p.Lon, &p.Speed, &p.TripID); err != nil {
+					posRows.Close()
+					return fmt.Errorf("scan position: %w", err)
+				}
+				positions = append(positions, p)
+			}
+			posRows.Close()
+
+			// Group by route+direction and reconstruct trips
+			byRouteDir := make(map[string][]PositionPoint)
+			for _, p := range positions {
+				r := p.Route
+				dirStr := "x"
+				if p.DirectionID != nil {
+					dirStr = fmt.Sprintf("%d", *p.DirectionID)
+				}
+				key := p.VehicleID + ":" + r + ":" + dirStr
+				byRouteDir[key] = append(byRouteDir[key], p)
+			}
+
+			for _, groupPositions := range byRouteDir {
+				allTrips = append(allTrips, reconstructTrips(groupPositions, 10)...)
+			}
+
+			processedVehicles++
+			if processedVehicles%100 == 0 {
+				log.Printf("[aggregate] Reconstructed trips for %d/%d vehicles", processedVehicles, len(vehicles))
+			}
+
+			// Free memory for this vehicle
+			positions = nil
+		}
+	}
+
+	log.Printf("[aggregate] Reconstructed %d trips from %d vehicles", len(allTrips), len(vehicles))
+
+	// Store trip logs
+	if len(allTrips) > 0 {
+		_, err := pool.Exec(ctx, `DELETE FROM "TripLog" WHERE date = $1`, yesterday)
+		if err != nil {
+			return fmt.Errorf("delete old trips: %w", err)
+		}
+		for i := 0; i < len(allTrips); i += 500 {
+			end := i + 500
+			if end > len(allTrips) {
+				end = len(allTrips)
+			}
+			batch := allTrips[i:end]
+			query := `INSERT INTO "TripLog" (date, "vehicleId", "vehicleNum", route, "tripId", "directionId", "startedAt", "endedAt", "runtimeSecs", positions, "avgSpeed") VALUES `
+			var args []interface{}
+			var placeholders []string
+			for j, t := range batch {
+				base := j * 11
+				placeholders = append(placeholders, fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)",
+					base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8, base+9, base+10, base+11))
+				var avgSpeed *float64
+				if t.AvgSpeed > 0 {
+					v := t.AvgSpeed
+					avgSpeed = &v
+				}
+				args = append(args, yesterday, t.VehicleID, t.VehicleNum, t.Route, t.TripID, t.DirectionID, t.StartedAt, t.EndedAt, t.RuntimeSecs, t.Positions, avgSpeed)
+			}
+			query += strings.Join(placeholders, ",")
+			if _, err := pool.Exec(ctx, query, args...); err != nil {
+				return fmt.Errorf("insert trips: %w", err)
+			}
+		}
+	}
+
+	// Segment speed aggregation (from memory - small)
+	if len(segDefs) > 0 && len(hourlySegmentSpeeds) > 0 {
+		_, err := pool.Exec(ctx,
+			`DELETE FROM "SegmentSpeedHourly" WHERE "hourStart" >= $1 AND "hourStart" < $2`,
+			yesterday, today)
+		if err != nil {
+			return fmt.Errorf("delete old segment speeds: %w", err)
+		}
+		segByID := make(map[string]*SegmentDef, len(segDefs))
+		for i := range segDefs {
+			segByID[segDefs[i].ID] = &segDefs[i]
+		}
+		type segSpeedRow struct {
+			segmentID   string
+			route       string
+			directionID int
+			hourStart   time.Time
+			avgSpeed    float64
+			medianSpeed float64
+			p10Speed    float64
+			p90Speed    float64
+			sampleCount int
+		}
+		var segSpeedRows []segSpeedRow
+		for key, speeds := range hourlySegmentSpeeds {
+			if len(speeds) < 2 {
+				continue
+			}
+			var segID, hourISO string
+			for i := len(key) - 1; i >= 0; i-- {
+				if key[i] == ':' {
+					candidate := key[:i]
+					if _, ok := segByID[candidate]; ok {
+						segID = candidate
+						hourISO = key[i+1:]
+						break
+					}
+				}
+			}
+			if segID == "" {
+				continue
+			}
+			seg := segByID[segID]
+			hourStart, err := time.Parse(time.RFC3339, hourISO)
+			if err != nil {
+				continue
+			}
+			avg := 0.0
+			for _, s := range speeds {
+				avg += s
+			}
+			avg /= float64(len(speeds))
+			segSpeedRows = append(segSpeedRows, segSpeedRow{
+				segmentID:   segID,
+				route:       seg.Route,
+				directionID: seg.DirectionID,
+				hourStart:   hourStart,
+				avgSpeed:    math.Round(avg*10) / 10,
+				medianSpeed: math.Round(percentile(speeds, 50)*10) / 10,
+				p10Speed:    math.Round(percentile(speeds, 10)*10) / 10,
+				p90Speed:    math.Round(percentile(speeds, 90)*10) / 10,
+				sampleCount: len(speeds),
+			})
+		}
+		hourlySegmentSpeeds = nil
+		for i := 0; i < len(segSpeedRows); i += 500 {
+			end := i + 500
+			if end > len(segSpeedRows) {
+				end = len(segSpeedRows)
+			}
+			batch := segSpeedRows[i:end]
+			query := `INSERT INTO "SegmentSpeedHourly" ("segmentId", route, "directionId", "hourStart", "avgSpeed", "medianSpeed", "p10Speed", "p90Speed", "sampleCount") VALUES `
+			var args []interface{}
+			var placeholders []string
+			for j, r := range batch {
+				base := j * 9
+				placeholders = append(placeholders, fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)",
+					base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8, base+9))
+				args = append(args, r.segmentID, r.route, r.directionID, r.hourStart, r.avgSpeed, r.medianSpeed, r.p10Speed, r.p90Speed, r.sampleCount)
+			}
+			query += strings.Join(placeholders, ",")
+			if _, err := pool.Exec(ctx, query, args...); err != nil {
+				return fmt.Errorf("insert segment speeds: %w", err)
+			}
+		}
+		log.Printf("[aggregate] Computed %d segment speed aggregates", len(segSpeedRows))
+	}
+
+	// Route performance daily
+	routeTrips := make(map[string][]ReconstructedTrip)
+	for _, trip := range allTrips {
+		dirStr := "x"
+		if trip.DirectionID != nil {
+			dirStr = fmt.Sprintf("%d", *trip.DirectionID)
+		}
+		key := trip.Route + ":" + dirStr
+		routeTrips[key] = append(routeTrips[key], trip)
+	}
+	_, err = pool.Exec(ctx, `DELETE FROM "RoutePerformanceDaily" WHERE date = $1`, yesterday)
+	if err != nil {
+		return fmt.Errorf("delete old route perf: %w", err)
+	}
+	type routePerfRow struct {
+		route               string
+		directionID         *int16
+		tripsObserved       int
+		avgHeadwaySecs      *float64
+		headwayAdherencePct *float64
+		excessWaitTimeSecs  *float64
+		avgRuntimeSecs      *int
+		avgCommercialSpeed  *float64
+		bunchingPct         *float64
+		gappingPct          *float64
+	}
+	var routePerfRows []routePerfRow
+	for key, trips := range routeTrips {
+		parts := strings.SplitN(key, ":", 2)
+		route := parts[0]
+		var directionID *int16
+		if parts[1] != "x" {
+			var d int16
+			fmt.Sscanf(parts[1], "%d", &d)
+			directionID = &d
+		}
+		startTimes := make([]int64, len(trips))
+		for i, t := range trips {
+			startTimes[i] = t.StartedAt.UnixMilli()
+		}
+		sort.Slice(startTimes, func(i, j int) bool { return startTimes[i] < startTimes[j] })
+		headwayMetrics := computeHeadwayMetrics(startTimes, nil)
+		var runtimes []float64
+		for _, t := range trips {
+			if t.RuntimeSecs > 60 {
+				runtimes = append(runtimes, float64(t.RuntimeSecs))
+			}
+		}
+		var avgRuntime *int
+		if len(runtimes) > 0 {
+			sum := 0.0
+			for _, r := range runtimes {
+				sum += r
+			}
+			v := int(math.Round(sum / float64(len(runtimes))))
+			avgRuntime = &v
+		}
+		var speeds []float64
+		for _, t := range trips {
+			if t.AvgSpeed > 0 {
+				speeds = append(speeds, t.AvgSpeed)
+			}
+		}
+		var avgCommercialSpeed *float64
+		if len(speeds) > 0 {
+			sum := 0.0
+			for _, s := range speeds {
+				sum += s
+			}
+			v := math.Round(sum/float64(len(speeds))*10) / 10
+			avgCommercialSpeed = &v
+		}
+		rp := routePerfRow{
+			route:              route,
+			directionID:        directionID,
+			tripsObserved:      len(trips),
+			avgRuntimeSecs:     avgRuntime,
+			avgCommercialSpeed: avgCommercialSpeed,
+		}
+		if headwayMetrics != nil {
+			ahs := float64(headwayMetrics.AvgHeadwaySecs)
+			rp.avgHeadwaySecs = &ahs
+			rp.headwayAdherencePct = &headwayMetrics.HeadwayAdherencePct
+			ewt := float64(headwayMetrics.ExcessWaitTimeSecs)
+			rp.excessWaitTimeSecs = &ewt
+			rp.bunchingPct = &headwayMetrics.BunchingPct
+			rp.gappingPct = &headwayMetrics.GappingPct
+		}
+		routePerfRows = append(routePerfRows, rp)
+	}
+	if len(routePerfRows) > 0 {
+		for i := 0; i < len(routePerfRows); i += 500 {
+			end := i + 500
+			if end > len(routePerfRows) {
+				end = len(routePerfRows)
+			}
+			batch := routePerfRows[i:end]
+			query := `INSERT INTO "RoutePerformanceDaily" (date, route, "directionId", "tripsObserved", "avgHeadwaySecs", "headwayAdherencePct", "excessWaitTimeSecs", "avgRuntimeSecs", "avgCommercialSpeed", "bunchingPct", "gappingPct") VALUES `
+			var args []interface{}
+			var placeholders []string
+			for j, r := range batch {
+				base := j * 11
+				placeholders = append(placeholders, fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)",
+					base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8, base+9, base+10, base+11))
+				args = append(args, yesterday, r.route, r.directionID, r.tripsObserved, r.avgHeadwaySecs, r.headwayAdherencePct, r.excessWaitTimeSecs, r.avgRuntimeSecs, r.avgCommercialSpeed, r.bunchingPct, r.gappingPct)
+			}
+			query += strings.Join(placeholders, ",")
+			if _, err := pool.Exec(ctx, query, args...); err != nil {
+				return fmt.Errorf("insert route perf: %w", err)
+			}
+		}
+	}
+	log.Printf("[aggregate] Computed performance for %d route-directions", len(routePerfRows))
+
+	// Stop headway irregularity (from memory - small)
+	if len(stopArrivals) > 0 {
+		_, err := pool.Exec(ctx, `DELETE FROM "StopHeadwayDaily" WHERE date = $1`, yesterday)
+		if err != nil {
+			return fmt.Errorf("delete old stop headway: %w", err)
+		}
+		type headwayRow struct {
+			route          string
+			directionID    *int16
+			stopID         string
+			stopName       *string
+			stopSequence   int
+			avgHeadwaySecs int
+			headwayStdDev  float64
+			observations   int
+		}
+		var headwayRows []headwayRow
+		for stopKey, arrivals := range stopArrivals {
+			if len(arrivals) < 3 {
+				continue
+			}
+			sort.Slice(arrivals, func(i, j int) bool { return arrivals[i] < arrivals[j] })
+			headways := make([]float64, 0, len(arrivals)-1)
+			for i := 1; i < len(arrivals); i++ {
+				headways = append(headways, float64(arrivals[i]-arrivals[i-1])/1000.0)
+			}
+			avg := 0.0
+			for _, h := range headways {
+				avg += h
+			}
+			avg /= float64(len(headways))
+			variance := 0.0
+			for _, h := range headways {
+				variance += (h - avg) * (h - avg)
+			}
+			variance /= float64(len(headways))
+			stdDev := math.Sqrt(variance)
+			firstColon := strings.Index(stopKey, ":")
+			secondColon := strings.Index(stopKey[firstColon+1:], ":") + firstColon + 1
+			route := stopKey[:firstColon]
+			dirStr := stopKey[firstColon+1 : secondColon]
+			stopID := stopKey[secondColon+1:]
+			var directionID *int16
+			if dirStr != "x" {
+				var d int16
+				fmt.Sscanf(dirStr, "%d", &d)
+				directionID = &d
+			}
+			var stopName *string
+			stopSeq := 0
+			stopsForRoute := stopsByRoute[route]
+			for _, rs := range stopsForRoute {
+				if rs.StopID == stopID && (directionID == nil || rs.DirectionID == int(*directionID)) {
+					stopName = rs.StopName
+					stopSeq = rs.StopSeq
+					break
+				}
+			}
+			headwayRows = append(headwayRows, headwayRow{
+				route:          route,
+				directionID:    directionID,
+				stopID:         stopID,
+				stopName:       stopName,
+				stopSequence:   stopSeq,
+				avgHeadwaySecs: int(math.Round(avg)),
+				headwayStdDev:  math.Round(stdDev*10) / 10,
+				observations:   len(arrivals),
+			})
+		}
+		for i := 0; i < len(headwayRows); i += 500 {
+			end := i + 500
+			if end > len(headwayRows) {
+				end = len(headwayRows)
+			}
+			batch := headwayRows[i:end]
+			query := `INSERT INTO "StopHeadwayDaily" (date, route, "directionId", "stopId", "stopName", "stopSequence", "avgHeadwaySecs", "headwayStdDev", observations) VALUES `
+			var args []interface{}
+			var placeholders []string
+			for j, r := range batch {
+				base := j * 9
+				placeholders = append(placeholders, fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)",
+					base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8, base+9))
+				args = append(args, yesterday, r.route, r.directionID, r.stopID, r.stopName, r.stopSequence, r.avgHeadwaySecs, r.headwayStdDev, r.observations)
+			}
+			query += strings.Join(placeholders, ",")
+			if _, err := pool.Exec(ctx, query, args...); err != nil {
+				return fmt.Errorf("insert stop headway: %w", err)
+			}
+		}
+		log.Printf("[aggregate] Computed headway irregularity for %d stops", len(headwayRows))
+	}
+
+	// Network summary
+	uniqueVehicles := make(map[string]struct{})
+	for _, t := range allTrips {
+		uniqueVehicles[t.VehicleID] = struct{}{}
+	}
+	var allSpeeds []float64
+	var allEwt []float64
+	for _, r := range routePerfRows {
+		if r.avgCommercialSpeed != nil {
+			allSpeeds = append(allSpeeds, *r.avgCommercialSpeed)
+		}
+		if r.excessWaitTimeSecs != nil {
+			allEwt = append(allEwt, *r.excessWaitTimeSecs)
+		}
+	}
+	var networkAvgSpeed, networkAvgEwt *float64
+	if len(allSpeeds) > 0 {
+		sum := 0.0
+		for _, s := range allSpeeds {
+			sum += s
+		}
+		v := math.Round(sum/float64(len(allSpeeds))*10) / 10
+		networkAvgSpeed = &v
+	}
+	if len(allEwt) > 0 {
+		sum := 0.0
+		for _, e := range allEwt {
+			sum += e
+		}
+		v := math.Round(sum / float64(len(allEwt)))
+		networkAvgEwt = &v
+	}
+	var worstRoute *string
+	var worstEwt *float64
+	for _, r := range routePerfRows {
+		if r.excessWaitTimeSecs != nil && (worstEwt == nil || *r.excessWaitTimeSecs > *worstEwt) {
+			worstEwt = r.excessWaitTimeSecs
+			worstRoute = &r.route
+		}
+	}
+	_, err = pool.Exec(ctx, `
+		INSERT INTO "NetworkSummaryDaily" (date, "activeVehicles", "totalTrips", "avgCommercialSpeed", "avgExcessWaitTime", "worstRoute", "worstRouteEwt", "positionsCollected")
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		ON CONFLICT (date) DO UPDATE SET
+			"activeVehicles" = EXCLUDED."activeVehicles",
+			"totalTrips" = EXCLUDED."totalTrips",
+			"avgCommercialSpeed" = EXCLUDED."avgCommercialSpeed",
+			"avgExcessWaitTime" = EXCLUDED."avgExcessWaitTime",
+			"worstRoute" = EXCLUDED."worstRoute",
+			"worstRouteEwt" = EXCLUDED."worstRouteEwt",
+			"positionsCollected" = EXCLUDED."positionsCollected"
+	`, yesterday, len(uniqueVehicles), len(allTrips), networkAvgSpeed, networkAvgEwt, worstRoute, worstEwt, totalPositions)
+	if err != nil {
+		return fmt.Errorf("upsert network summary: %w", err)
+	}
+
+	elapsed := time.Since(startTime)
+	log.Printf("[aggregate] Complete for %s: %d positions, %d trips in %s", dateStr, totalPositions, len(allTrips), elapsed)
+	return nil
+}

--- a/worker/main.go
+++ b/worker/main.go
@@ -59,7 +59,7 @@ func main() {
 				return runSnapshotSchedule(ctx, pool)
 			}},
 			{name: "aggregate-daily", hour: 3, dayOfWeek: nil, fn: func(ctx context.Context) error {
-				return runAggregateDaily(ctx, pool, r2, bucket)
+				return runAggregateDailyIncremental(ctx, pool, r2, bucket, time.Time{})
 			}},
 			{name: "archive-positions", hour: 3, dayOfWeek: nil, fn: func(ctx context.Context) error {
 				return runArchivePositions(ctx, r2, bucket)
@@ -99,7 +99,7 @@ func main() {
 						log.Fatalf("[run] Invalid DATE format (use YYYY-MM-DD): %v", err)
 					}
 					log.Printf("[run] Using date override: %s", dateStr)
-					if err := runAggregateDailyWithDate(ctx, pool, r2, bucket, overrideDate); err != nil {
+					if err := runAggregateDailyIncremental(ctx, pool, r2, bucket, overrideDate); err != nil {
 						log.Fatalf("[run] aggregate-daily failed: %v", err)
 					}
 					log.Printf("[run] aggregate-daily completed successfully")

--- a/worker/main.go
+++ b/worker/main.go
@@ -71,34 +71,39 @@ func main() {
 				return runRefreshSegments(ctx, pool)
 			}},
 		}
+
+		// --- CLI mode: run a specific job and exit ---
+		if len(os.Args) >= 3 && os.Args[1] == "run" {
+			jobName := os.Args[2]
+			var target *scheduledJob
+			for i := range jobs {
+				if jobs[i].name == jobName {
+					target = &jobs[i]
+					break
+				}
+			}
+			if target == nil {
+				log.Printf("Unknown job: %s", jobName)
+				log.Printf("Available jobs:")
+				for _, j := range jobs {
+					log.Printf("  - %s", j.name)
+				}
+				os.Exit(1)
+			}
+			log.Printf("[run] Executing %s...", target.name)
+			if err := target.fn(ctx); err != nil {
+				log.Fatalf("[run] %s failed: %v", target.name, err)
+			}
+			log.Printf("[run] %s completed successfully", target.name)
+			return
+		}
 	} else {
 		log.Println("WARNING: DATABASE_URL not set — scheduled jobs (aggregate, archive, cleanup) disabled")
-	}
 
-	// --- CLI mode: run a specific job and exit ---
-	if len(os.Args) >= 3 && os.Args[1] == "run" {
-		jobName := os.Args[2]
-		var target *scheduledJob
-		for i := range jobs {
-			if jobs[i].name == jobName {
-				target = &jobs[i]
-				break
-			}
+		// CLI mode without DATABASE_URL - list available jobs
+		if len(os.Args) >= 3 && os.Args[1] == "run" {
+			log.Fatal("[run] DATABASE_URL not configured — cannot run scheduled jobs that require database")
 		}
-		if target == nil {
-			log.Printf("Unknown job: %s", jobName)
-			log.Printf("Available jobs:")
-			for _, j := range jobs {
-				log.Printf("  - %s", j.name)
-			}
-			os.Exit(1)
-		}
-		log.Printf("[run] Executing %s...", target.name)
-		if err := target.fn(ctx); err != nil {
-			log.Fatalf("[run] %s failed: %v", target.name, err)
-		}
-		log.Printf("[run] %s completed successfully", target.name)
-		return
 	}
 
 	maskedURL := maskDatabaseURL(dbURL)

--- a/worker/main.go
+++ b/worker/main.go
@@ -90,6 +90,23 @@ func main() {
 				}
 				os.Exit(1)
 			}
+
+			// Support DATE env var for aggregate-daily to backfill historical data
+			if target.name == "aggregate-daily" {
+				if dateStr := os.Getenv("DATE"); dateStr != "" {
+					overrideDate, err := time.Parse("2006-01-02", dateStr)
+					if err != nil {
+						log.Fatalf("[run] Invalid DATE format (use YYYY-MM-DD): %v", err)
+					}
+					log.Printf("[run] Using date override: %s", dateStr)
+					if err := runAggregateDailyWithDate(ctx, pool, r2, bucket, overrideDate); err != nil {
+						log.Fatalf("[run] aggregate-daily failed: %v", err)
+					}
+					log.Printf("[run] aggregate-daily completed successfully")
+					return
+				}
+			}
+
 			log.Printf("[run] Executing %s...", target.name)
 			if err := target.fn(ctx); err != nil {
 				log.Fatalf("[run] %s failed: %v", target.name, err)
@@ -100,7 +117,7 @@ func main() {
 	} else {
 		log.Println("WARNING: DATABASE_URL not set — scheduled jobs (aggregate, archive, cleanup) disabled")
 
-		// CLI mode without DATABASE_URL - list available jobs
+		// CLI mode without DATABASE_URL
 		if len(os.Args) >= 3 && os.Args[1] == "run" {
 			log.Fatal("[run] DATABASE_URL not configured — cannot run scheduled jobs that require database")
 		}


### PR DESCRIPTION
## TypeScript 6.0 Upgrade

TypeScript 6.0 is now available. This PR upgrades the project and addresses breaking changes.

### Changes
- Bump `typescript` to `^6.0.0`
- Update `tsconfig.json` for TS6 breaking changes

### Key TS6 breaking changes addressed
- `types` now defaults to `[]` — added explicit `types` array where needed
- `baseUrl` deprecated — migrated path aliases to use explicit prefixes in `paths`
- `moduleResolution: node` deprecated — updated to `node16` or `bundler`
- `dom.iterable` is now included in `dom` lib (no action needed, backward compatible)

### Notes
- TypeScript 7.0 (native Go port) is coming soon; TS6 is the bridge release
- `strict`, `esModuleInterop`, `alwaysStrict` can no longer be set to `false` (none affected here)
- `target: es5` and `--outFile` are removed (not used here)