### PR TITLE
feat: rewrite worker in Python with DuckDB 1.5.3

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -18,4 +18,3 @@ primary_region = 'cdg'
   size = 'shared-cpu-1x'
   memory = '512mb'
   cpus = 1
-  memory_mb = 512

--- a/fly.toml
+++ b/fly.toml
@@ -1,18 +1,16 @@
-# fly.toml — PortoMove Worker (Go collector)
-# Lives at repo root so the Fly.io GitHub integration can find it.
-
+# fly.toml — PortoMove Worker (Python/DuckDB)
 app = 'portomove-collector'
 primary_region = 'cdg'
 
 [build]
-  dockerfile = "worker/Dockerfile"
+  dockerfile = "worker-py/Dockerfile"
 
 [env]
   TZ = 'UTC'
 
 # No http_service — this is a background worker, not a web server
 [processes]
-  worker = "/worker"
+  worker = "python -m worker.main"
 
 [[vm]]
   size = 'shared-cpu-1x'

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "prettier": "^3.8.1",
     "prisma": "^7.4.2",
     "tailwindcss": "^4.2.1",
-    "typescript": "^5",
+    "typescript": "^6.0.0",
     "vitest": "^4.0.18"
   },
   "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
         version: 1.2.1
       '@neondatabase/auth':
         specifier: 0.2.0-beta.1
-        version: 0.2.0-beta.1(aehyzkj67jxi5ax6lrhclyl4du)
+        version: 0.2.0-beta.1(fr4ocq3jm5443oif6yffs2yiue)
       '@neondatabase/serverless':
         specifier: ^1.0.2
         version: 1.0.2
@@ -39,7 +39,7 @@ importers:
         version: 7.4.2
       '@prisma/client':
         specifier: ^7.4.2
-        version: 7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2)
       dotenv:
         specifier: ^17.3.1
         version: 17.3.1
@@ -76,7 +76,7 @@ importers:
         version: 9.6.0(@types/node@25.3.3)
       '@stryker-mutator/vitest-runner':
         specifier: ^9.6.0
-        version: 9.6.0(@stryker-mutator/core@9.6.0(@types/node@25.3.3))(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 9.6.0(@stryker-mutator/core@9.6.0(@types/node@25.3.3))(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       '@tailwindcss/postcss':
         specifier: ^4.2.1
         version: 4.2.1
@@ -94,7 +94,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.0.18(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -103,7 +103,7 @@ importers:
         version: 9.39.2(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.1.6
-        version: 16.1.6(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.1.6(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
         version: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -112,7 +112,7 @@ importers:
         version: 9.1.7
       knip:
         specifier: ^5.85.0
-        version: 5.85.0(@types/node@25.3.3)(typescript@5.9.3)
+        version: 5.85.0(@types/node@25.3.3)(typescript@6.0.2)
       lint-staged:
         specifier: ^16.3.2
         version: 16.3.2
@@ -124,16 +124,16 @@ importers:
         version: 3.8.1
       prisma:
         specifier: ^7.4.2
-        version: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+        version: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)
       tailwindcss:
         specifier: ^4.2.1
         version: 4.2.1
       typescript:
-        specifier: ^5
-        version: 5.9.3
+        specifier: ^6.0.0
+        version: 6.0.2
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 
@@ -1000,8 +1000,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.4':
+    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.3':
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.4':
+    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1012,8 +1024,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.4':
+    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.3':
     resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.4':
+    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1024,8 +1048,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.4':
+    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.3':
     resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.4':
+    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1036,8 +1072,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.4':
+    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.3':
     resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.4':
+    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1048,8 +1096,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.4':
+    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.3':
     resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.4':
+    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1060,8 +1120,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.4':
+    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.3':
     resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.4':
+    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1072,8 +1144,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.4':
+    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.3':
     resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.4':
+    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1084,8 +1168,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.4':
+    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.3':
     resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.4':
+    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1096,8 +1192,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.4':
+    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.3':
     resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1108,8 +1216,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.4':
+    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.3':
     resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1120,8 +1240,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.4':
+    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.3':
     resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1132,8 +1264,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.4':
+    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.3':
     resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.4':
+    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1144,8 +1288,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.4':
+    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.3':
     resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.4':
+    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2649,11 +2805,11 @@ packages:
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
-  '@simplewebauthn/browser@13.2.2':
-    resolution: {integrity: sha512-FNW1oLQpTJyqG5kkDg5ZsotvWgmBaC6jCHR7Ej0qUNep36Wl9tj2eZu7J5rP+uhXgHaLk+QQ3lqcw2vS5MX1IA==}
+  '@simplewebauthn/browser@13.3.0':
+    resolution: {integrity: sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==}
 
-  '@simplewebauthn/server@13.2.3':
-    resolution: {integrity: sha512-ZhcVBOw63birYx9jVfbhK6rTehckVes8PeWV324zpmdxr0BUfylospwMzcrxrdMcOi48MHWj2LCA+S528LnGvg==}
+  '@simplewebauthn/server@13.3.0':
+    resolution: {integrity: sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ==}
     engines: {node: '>=20.0.0'}
 
   '@sindresorhus/merge-streams@4.0.0':
@@ -3110,6 +3266,9 @@ packages:
 
   '@types/node@25.3.3':
     resolution: {integrity: sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==}
+
+  '@types/node@25.5.0':
+    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -3792,8 +3951,8 @@ packages:
   core-js-compat@3.48.0:
     resolution: {integrity: sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==}
 
-  core-js@3.48.0:
-    resolution: {integrity: sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==}
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -3999,6 +4158,10 @@ packages:
     resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
     engines: {node: '>=10.13.0'}
 
+  enhanced-resolve@5.20.1:
+    resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
+    engines: {node: '>=10.13.0'}
+
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
@@ -4053,6 +4216,11 @@ packages:
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.4:
+    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4396,6 +4564,9 @@ packages:
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
+  get-tsconfig@4.13.7:
+    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
   giget@2.0.0:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
     hasBin: true
@@ -4480,8 +4651,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.12.5:
-    resolution: {integrity: sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==}
+  hono@4.12.9:
+    resolution: {integrity: sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@2.8.9:
@@ -5110,8 +5281,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.6:
-    resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
+  nanoid@5.1.7:
+    resolution: {integrity: sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -5931,6 +6102,10 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tapable@2.3.2:
+    resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
+    engines: {node: '>=6'}
+
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
     engines: {node: '>=8'}
@@ -5939,8 +6114,8 @@ packages:
     resolution: {integrity: sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==}
     engines: {node: '>=10'}
 
-  terser-webpack-plugin@5.3.17:
-    resolution: {integrity: sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==}
+  terser-webpack-plugin@5.4.0:
+    resolution: {integrity: sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -5957,6 +6132,11 @@ packages:
 
   terser@5.46.0:
     resolution: {integrity: sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  terser@5.46.1:
+    resolution: {integrity: sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -6075,8 +6255,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -7640,14 +7820,14 @@ snapshots:
       '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/passkey@1.4.18(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)':
+  '@better-auth/passkey@1.4.18(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)':
     dependencies:
       '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
-      '@simplewebauthn/browser': 13.2.2
-      '@simplewebauthn/server': 13.2.3
-      better-auth: 1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@simplewebauthn/browser': 13.3.0
+      '@simplewebauthn/server': 13.3.0
+      better-auth: 1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       better-call: 1.3.2(zod@4.3.6)
       nanostores: 1.1.1
       zod: 4.3.6
@@ -7685,20 +7865,20 @@ snapshots:
 
   '@chevrotain/utils@10.5.0': {}
 
-  '@daveyplate/better-auth-tanstack@1.3.6(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(better-auth@1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@daveyplate/better-auth-tanstack@1.3.6(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(better-auth@1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@tanstack/query-core': 5.90.20
       '@tanstack/react-query': 5.90.21(react@19.2.4)
-      better-auth: 1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      better-auth: 1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@daveyplate/better-auth-ui@3.3.9(sweajfz5kysgunwzvufmpmeo2y)':
+  '@daveyplate/better-auth-ui@3.3.9(qxh5xkt2xvzb2lkwxisvtwanma)':
     dependencies:
-      '@better-auth/passkey': 1.4.18(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
+      '@better-auth/passkey': 1.4.18(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
       '@better-fetch/fetch': 1.1.21
       '@captchafox/react': 1.10.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@daveyplate/better-auth-tanstack': 1.3.6(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(better-auth@1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@daveyplate/better-auth-tanstack': 1.3.6(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(better-auth@1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@hcaptcha/react-hcaptcha': 1.17.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@hookform/resolvers': 5.2.2(react-hook-form@7.71.1(react@19.2.4))
       '@instantdb/react': 0.22.138(react@19.2.4)
@@ -7719,10 +7899,10 @@ snapshots:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@react-email/components': 1.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-query': 5.90.21(react@19.2.4)
-      '@triplit/client': 1.0.50(typescript@5.9.3)
-      '@triplit/react': 1.0.51(react@19.2.4)(typescript@5.9.3)
+      '@triplit/client': 1.0.50(typescript@6.0.2)
+      '@triplit/react': 1.0.51(react@19.2.4)(typescript@6.0.2)
       '@wojtekmaj/react-recaptcha-v3': 0.1.4(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      better-auth: 1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      better-auth: 1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       class-variance-authority: 0.7.1
       clsx: 2.1.1
       input-otp: 1.4.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -7785,79 +7965,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.4':
+    optional: true
+
   '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.4':
     optional: true
 
   '@esbuild/android-arm@0.27.3':
     optional: true
 
+  '@esbuild/android-arm@0.27.4':
+    optional: true
+
   '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.4':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.3':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.4':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.4':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.3':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.4':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.4':
     optional: true
 
   '@esbuild/linux-arm64@0.27.3':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.4':
+    optional: true
+
   '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.4':
     optional: true
 
   '@esbuild/linux-ia32@0.27.3':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.4':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.4':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.3':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.4':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.4':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.3':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.4':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.4':
     optional: true
 
   '@esbuild/linux-x64@0.27.3':
     optional: true
 
+  '@esbuild/linux-x64@0.27.4':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.4':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.4':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.4':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.4':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.4':
     optional: true
 
   '@esbuild/sunos-x64@0.27.3':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.4':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.4':
     optional: true
 
   '@esbuild/win32-ia32@0.27.3':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.4':
+    optional: true
+
   '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.4':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
@@ -7934,9 +8192,9 @@ snapshots:
 
   '@hexagon/base64@1.1.28': {}
 
-  '@hono/node-server@1.19.11(hono@4.12.5)':
+  '@hono/node-server@1.19.11(hono@4.12.9)':
     dependencies:
-      hono: 4.12.5
+      hono: 4.12.9
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.71.1(react@19.2.4))':
     dependencies:
@@ -8246,14 +8504,14 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@neondatabase/auth-ui@0.1.0-alpha.11(wzlt2jxmezzfsbawek6tsr5ybi)':
+  '@neondatabase/auth-ui@0.1.0-alpha.11(hitrpspx67gibqz6lwot5bedoe)':
     dependencies:
       '@captchafox/react': 1.10.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@daveyplate/better-auth-ui': 3.3.9(sweajfz5kysgunwzvufmpmeo2y)
+      '@daveyplate/better-auth-ui': 3.3.9(qxh5xkt2xvzb2lkwxisvtwanma)
       '@hcaptcha/react-hcaptcha': 1.17.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@hookform/resolvers': 5.2.2(react-hook-form@7.71.1(react@19.2.4))
       '@marsidev/react-turnstile': 1.4.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@neondatabase/auth': 0.2.0-beta.1(aehyzkj67jxi5ax6lrhclyl4du)
+      '@neondatabase/auth': 0.2.0-beta.1(fr4ocq3jm5443oif6yffs2yiue)
       '@radix-ui/react-avatar': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-context': 1.1.3(@types/react@19.2.14)(react@19.2.4)
@@ -8296,11 +8554,11 @@ snapshots:
       - '@types/react-dom'
       - better-auth
 
-  '@neondatabase/auth@0.2.0-beta.1(aehyzkj67jxi5ax6lrhclyl4du)':
+  '@neondatabase/auth@0.2.0-beta.1(fr4ocq3jm5443oif6yffs2yiue)':
     dependencies:
-      '@neondatabase/auth-ui': 0.1.0-alpha.11(wzlt2jxmezzfsbawek6tsr5ybi)
+      '@neondatabase/auth-ui': 0.1.0-alpha.11(hitrpspx67gibqz6lwot5bedoe)
       '@supabase/auth-js': 2.79.0
-      better-auth: 1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      better-auth: 1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       jose: 6.1.2
       zod: 4.1.12
     optionalDependencies:
@@ -8560,12 +8818,12 @@ snapshots:
 
   '@prisma/client-runtime-utils@7.4.2': {}
 
-  '@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)':
+  '@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2)':
     dependencies:
       '@prisma/client-runtime-utils': 7.4.2
     optionalDependencies:
-      prisma: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      typescript: 5.9.3
+      prisma: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)
+      typescript: 6.0.2
 
   '@prisma/config@7.4.2':
     dependencies:
@@ -8580,24 +8838,24 @@ snapshots:
 
   '@prisma/debug@7.4.2': {}
 
-  '@prisma/dev@0.20.0(typescript@5.9.3)':
+  '@prisma/dev@0.20.0(typescript@6.0.2)':
     dependencies:
       '@electric-sql/pglite': 0.3.15
       '@electric-sql/pglite-socket': 0.0.20(@electric-sql/pglite@0.3.15)
       '@electric-sql/pglite-tools': 0.2.20(@electric-sql/pglite@0.3.15)
-      '@hono/node-server': 1.19.11(hono@4.12.5)
+      '@hono/node-server': 1.19.11(hono@4.12.9)
       '@mrleebo/prisma-ast': 0.13.1
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0
       foreground-child: 3.3.1
       get-port-please: 3.2.0
-      hono: 4.12.5
+      hono: 4.12.9
       http-status-codes: 2.3.0
       pathe: 2.0.3
       proper-lockfile: 4.1.2
       remeda: 2.33.4
       std-env: 3.10.0
-      valibot: 1.2.0(typescript@5.9.3)
+      valibot: 1.2.0(typescript@6.0.2)
       zeptomatch: 2.1.0
     transitivePeerDependencies:
       - typescript
@@ -9305,9 +9563,9 @@ snapshots:
       domhandler: 5.0.3
       selderee: 0.11.0
 
-  '@simplewebauthn/browser@13.2.2': {}
+  '@simplewebauthn/browser@13.3.0': {}
 
-  '@simplewebauthn/server@13.2.3':
+  '@simplewebauthn/server@13.3.0':
     dependencies:
       '@hexagon/base64': 1.1.28
       '@levischuck/tiny-cbor': 0.2.11
@@ -9720,13 +9978,13 @@ snapshots:
 
   '@stryker-mutator/util@9.6.0': {}
 
-  '@stryker-mutator/vitest-runner@9.6.0(@stryker-mutator/core@9.6.0(@types/node@25.3.3))(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@stryker-mutator/vitest-runner@9.6.0(@stryker-mutator/core@9.6.0(@types/node@25.3.3))(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@stryker-mutator/api': 9.6.0
       '@stryker-mutator/core': 9.6.0(@types/node@25.3.3)
       '@stryker-mutator/util': 9.6.0
       tslib: 2.8.1
-      vitest: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@supabase/auth-js@2.79.0':
     dependencies:
@@ -9819,10 +10077,10 @@ snapshots:
       '@tanstack/query-core': 5.90.20
       react: 19.2.4
 
-  '@triplit/client@1.0.50(typescript@5.9.3)':
+  '@triplit/client@1.0.50(typescript@6.0.2)':
     dependencies:
-      '@triplit/db': 1.1.10(typescript@5.9.3)
-      '@triplit/logger': 0.0.3(typescript@5.9.3)
+      '@triplit/db': 1.1.10(typescript@6.0.2)
+      '@triplit/logger': 0.0.3(typescript@6.0.2)
       comlink: 4.4.2
       superjson: 2.2.6
     transitivePeerDependencies:
@@ -9832,24 +10090,24 @@ snapshots:
       - typescript
       - uuidv7
 
-  '@triplit/db@1.1.10(typescript@5.9.3)':
+  '@triplit/db@1.1.10(typescript@6.0.2)':
     dependencies:
-      '@triplit/logger': 0.0.3(typescript@5.9.3)
-      core-js: 3.48.0
+      '@triplit/logger': 0.0.3(typescript@6.0.2)
+      core-js: 3.49.0
       elen: 1.0.10
-      nanoid: 5.1.6
+      nanoid: 5.1.7
       sorted-btree: 1.8.1
       web-worker: 1.5.0
     transitivePeerDependencies:
       - typescript
 
-  '@triplit/logger@0.0.3(typescript@5.9.3)':
+  '@triplit/logger@0.0.3(typescript@6.0.2)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
-  '@triplit/react@1.0.51(react@19.2.4)(typescript@5.9.3)':
+  '@triplit/react@1.0.51(react@19.2.4)(typescript@6.0.2)':
     dependencies:
-      '@triplit/client': 1.0.50(typescript@5.9.3)
+      '@triplit/client': 1.0.50(typescript@6.0.2)
       react: 19.2.4
     transitivePeerDependencies:
       - better-sqlite3
@@ -9928,6 +10186,10 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/node@25.5.0':
+    dependencies:
+      undici-types: 7.18.2
+
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/pg@8.16.0':
@@ -9950,40 +10212,40 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
-  '@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
       '@typescript-eslint/scope-manager': 8.55.0
-      '@typescript-eslint/type-utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.55.0
       eslint: 9.39.2(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.4.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.55.0
       '@typescript-eslint/types': 8.55.0
-      '@typescript-eslint/typescript-estree': 8.55.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.55.0(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.55.0
       debug: 4.4.3
       eslint: 9.39.2(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.55.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.55.0(typescript@6.0.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.55.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.55.0(typescript@6.0.2)
       '@typescript-eslint/types': 8.55.0
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -9992,47 +10254,47 @@ snapshots:
       '@typescript-eslint/types': 8.55.0
       '@typescript-eslint/visitor-keys': 8.55.0
 
-  '@typescript-eslint/tsconfig-utils@8.55.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.55.0(typescript@6.0.2)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
-  '@typescript-eslint/type-utils@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/types': 8.55.0
-      '@typescript-eslint/typescript-estree': 8.55.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.55.0(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
       debug: 4.4.3
       eslint: 9.39.2(jiti@2.6.1)
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.4.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.55.0': {}
 
-  '@typescript-eslint/typescript-estree@8.55.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.55.0(typescript@6.0.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.55.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.55.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.55.0(typescript@6.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.55.0(typescript@6.0.2)
       '@typescript-eslint/types': 8.55.0
       '@typescript-eslint/visitor-keys': 8.55.0
       debug: 4.4.3
       minimatch: 10.2.4
       semver: 7.7.4
       tinyglobby: 0.2.15
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.4.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.55.0
       '@typescript-eslint/types': 8.55.0
-      '@typescript-eslint/typescript-estree': 8.55.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.55.0(typescript@6.0.2)
       eslint: 9.39.2(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -10100,7 +10362,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -10112,7 +10374,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -10123,13 +10385,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -10431,7 +10693,7 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
-  better-auth@1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  better-auth@1.5.3(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/kysely-adapter': 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)
@@ -10448,13 +10710,13 @@ snapshots:
       nanostores: 1.1.1
       zod: 4.3.6
     optionalDependencies:
-      '@prisma/client': 7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
+      '@prisma/client': 7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2))(typescript@6.0.2)
       mysql2: 3.15.3
       next: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      prisma: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      prisma: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      vitest: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
 
@@ -10614,7 +10876,7 @@ snapshots:
     dependencies:
       browserslist: 4.28.1
 
-  core-js@3.48.0: {}
+  core-js@3.49.0: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -10796,6 +11058,11 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
+  enhanced-resolve@5.20.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.2
+
   entities@4.5.0: {}
 
   environment@1.1.0: {}
@@ -10940,24 +11207,54 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
 
+  esbuild@0.27.4:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.4
+      '@esbuild/android-arm': 0.27.4
+      '@esbuild/android-arm64': 0.27.4
+      '@esbuild/android-x64': 0.27.4
+      '@esbuild/darwin-arm64': 0.27.4
+      '@esbuild/darwin-x64': 0.27.4
+      '@esbuild/freebsd-arm64': 0.27.4
+      '@esbuild/freebsd-x64': 0.27.4
+      '@esbuild/linux-arm': 0.27.4
+      '@esbuild/linux-arm64': 0.27.4
+      '@esbuild/linux-ia32': 0.27.4
+      '@esbuild/linux-loong64': 0.27.4
+      '@esbuild/linux-mips64el': 0.27.4
+      '@esbuild/linux-ppc64': 0.27.4
+      '@esbuild/linux-riscv64': 0.27.4
+      '@esbuild/linux-s390x': 0.27.4
+      '@esbuild/linux-x64': 0.27.4
+      '@esbuild/netbsd-arm64': 0.27.4
+      '@esbuild/netbsd-x64': 0.27.4
+      '@esbuild/openbsd-arm64': 0.27.4
+      '@esbuild/openbsd-x64': 0.27.4
+      '@esbuild/openharmony-arm64': 0.27.4
+      '@esbuild/sunos-x64': 0.27.4
+      '@esbuild/win32-arm64': 0.27.4
+      '@esbuild/win32-ia32': 0.27.4
+      '@esbuild/win32-x64': 0.27.4
+    optional: true
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.1.6(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-next@16.1.6(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2):
     dependencies:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
       globals: 16.4.0
-      typescript-eslint: 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      typescript-eslint: 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-webpack
@@ -10983,22 +11280,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11009,7 +11306,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11021,7 +11318,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -11379,6 +11676,11 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  get-tsconfig@4.13.7:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+    optional: true
+
   giget@2.0.0:
     dependencies:
       citty: 0.1.6
@@ -11458,7 +11760,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.12.5: {}
+  hono@4.12.9: {}
 
   hosted-git-info@2.8.9: {}
 
@@ -11706,7 +12008,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.3.3
+      '@types/node': 25.5.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -11769,7 +12071,7 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  knip@5.85.0(@types/node@25.3.3)(typescript@5.9.3):
+  knip@5.85.0(@types/node@25.3.3)(typescript@6.0.2):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
       '@types/node': 25.3.3
@@ -11783,7 +12085,7 @@ snapshots:
       picomatch: 4.0.3
       smol-toml: 1.6.0
       strip-json-comments: 5.0.3
-      typescript: 5.9.3
+      typescript: 6.0.2
       zod: 4.3.6
 
   kysely@0.28.11: {}
@@ -12034,7 +12336,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  nanoid@5.1.6: {}
+  nanoid@5.1.7: {}
 
   nanostores@1.1.1: {}
 
@@ -12318,16 +12620,16 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
-  prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
+  prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@6.0.2):
     dependencies:
       '@prisma/config': 7.4.2
-      '@prisma/dev': 0.20.0(typescript@5.9.3)
+      '@prisma/dev': 0.20.0(typescript@6.0.2)
       '@prisma/engines': 7.4.2
       '@prisma/studio-core': 0.13.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       mysql2: 3.15.3
       postgres: 3.4.7
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - '@types/react'
       - magicast
@@ -12933,6 +13235,8 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tapable@2.3.2: {}
+
   temp-dir@2.0.0: {}
 
   tempy@0.6.0:
@@ -12942,18 +13246,25 @@ snapshots:
       type-fest: 0.16.0
       unique-string: 2.0.0
 
-  terser-webpack-plugin@5.3.17(webpack@5.105.0):
+  terser-webpack-plugin@5.4.0(webpack@5.105.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      terser: 5.46.0
+      terser: 5.46.1
       webpack: 5.105.0
 
   terser@5.46.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
       acorn: 8.15.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
+
+  terser@5.46.1:
+    dependencies:
+      '@jridgewell/source-map': 0.3.11
+      acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -12982,9 +13293,9 @@ snapshots:
 
   trim-newlines@3.0.1: {}
 
-  ts-api-utils@2.4.0(typescript@5.9.3):
+  ts-api-utils@2.4.0(typescript@6.0.2):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -12999,8 +13310,8 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.3
-      get-tsconfig: 4.13.6
+      esbuild: 0.27.4
+      get-tsconfig: 4.13.7
     optionalDependencies:
       fsevents: 2.3.3
     optional: true
@@ -13068,18 +13379,18 @@ snapshots:
       tunnel: 0.0.6
       underscore: 1.13.8
 
-  typescript-eslint@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.55.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/typescript-estree': 8.55.0(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
       eslint: 9.39.2(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   ua-is-frozen@0.1.2: {}
 
@@ -13178,9 +13489,9 @@ snapshots:
 
   uuid@11.1.0: {}
 
-  valibot@1.2.0(typescript@5.9.3):
+  valibot@1.2.0(typescript@6.0.2):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   validate-npm-package-license@3.0.4:
     dependencies:
@@ -13213,7 +13524,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -13226,14 +13537,14 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.31.1
-      terser: 5.46.0
+      terser: 5.46.1
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -13250,7 +13561,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.3.3
@@ -13303,7 +13614,7 @@ snapshots:
       acorn-import-phases: 1.0.4(acorn@8.16.0)
       browserslist: 4.28.1
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.20.0
+      enhanced-resolve: 5.20.1
       es-module-lexer: 2.0.0
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -13314,8 +13625,8 @@ snapshots:
       mime-types: 2.1.35
       neo-async: 2.6.2
       schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.3.17(webpack@5.105.0)
+      tapable: 2.3.2
+      terser-webpack-plugin: 5.4.0(webpack@5.105.0)
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,9 @@
     "paths": {
       "@/*": ["./*"]
     },
-    "target": "ES2023"
+    "target": "ES2023",
+    "types": ["node"],
+    "noUncheckedSideEffectImports": false
   },
   "include": [
     "next-env.d.ts",

--- a/worker-py/.dockerignore
+++ b/worker-py/.dockerignore
@@ -1,0 +1,6 @@
+.venv
+__pycache__
+*.egg-info
+.git
+.env
+.pytest_cache

--- a/worker-py/.env.example
+++ b/worker-py/.env.example
@@ -1,0 +1,8 @@
+# Neon Postgres
+DATABASE_URL=postgres://user:password@host/neondb?sslmode=require
+
+# Cloudflare R2
+R2_ENDPOINT=https://account.r2.cloudflarestorage.com
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET=porto-move

--- a/worker-py/.gitignore
+++ b/worker-py/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.egg-info/
+.venv/
+*.pyc

--- a/worker-py/.gitignore
+++ b/worker-py/.gitignore
@@ -2,3 +2,7 @@ __pycache__/
 *.egg-info/
 .venv/
 *.pyc
+.env
+dist/
+.pytest_cache/
+.DS_Store

--- a/worker-py/Dockerfile
+++ b/worker-py/Dockerfile
@@ -2,11 +2,11 @@ FROM python:3.12-slim
 
 WORKDIR /app
 COPY worker-py/pyproject.toml .
-RUN pip install --no-cache-dir .
-
 COPY worker-py/worker/ ./worker/
+RUN pip install --no-cache-dir . \
+    && python -c "import duckdb; db=duckdb.connect(); db.execute('INSTALL postgres'); db.execute('INSTALL httpfs')"
 
-# Pre-install DuckDB extensions
-RUN python -c "import duckdb; db=duckdb.connect(); db.execute('INSTALL postgres'); db.execute('INSTALL httpfs'); print('Extensions installed')"
+RUN useradd -r worker
+USER worker
 
 CMD ["python", "-m", "worker.main"]

--- a/worker-py/Dockerfile
+++ b/worker-py/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY worker-py/pyproject.toml .
+RUN pip install --no-cache-dir .
+
+COPY worker-py/worker/ ./worker/
+
+# Pre-install DuckDB extensions
+RUN python -c "import duckdb; db=duckdb.connect(); db.execute('INSTALL postgres'); db.execute('INSTALL httpfs'); print('Extensions installed')"
+
+CMD ["python", "-m", "worker.main"]

--- a/worker-py/README.md
+++ b/worker-py/README.md
@@ -1,0 +1,71 @@
+# PortoMove Worker
+
+Python worker that collects real-time bus positions from Porto's FIWARE platform and runs daily analytics aggregation using DuckDB.
+
+## Architecture
+
+- **Collection loop** (every 30s): Fetches bus positions from FIWARE → writes JSON snapshots to Cloudflare R2
+- **Scheduled jobs** (daily/weekly): DuckDB reads R2 snapshots, processes data, writes results to Neon PostgreSQL
+
+DuckDB handles all heavy processing with automatic spill-to-disk, keeping memory usage under 256MB.
+
+## Requirements
+
+- Python 3.12+
+- Environment variables (see `.env.example`)
+
+## Setup
+
+```bash
+uv venv && uv pip install -e ".[dev]"
+```
+
+## Running
+
+```bash
+# Start the worker (collection loop + scheduled jobs)
+python -m worker.main
+
+# Run a specific job manually
+python -m worker.main run aggregate-daily
+
+# Backfill a specific date
+DATE=2024-01-15 python -m worker.main run aggregate-daily
+```
+
+## Available Jobs
+
+| Job | Schedule | Description |
+|-----|----------|-------------|
+| `snapshot-schedule` | 01:00 UTC daily | Fetch scheduled trips from OTP |
+| `aggregate-daily` | 03:00 UTC daily | Process yesterday's positions → trips, route performance |
+| `archive-positions` | 03:00 UTC daily | Convert JSON snapshots to Parquet |
+| `cleanup-positions` | 04:00 UTC daily | Delete R2 snapshots older than 2 days |
+| `refresh-segments` | 05:00 UTC Monday | Refresh route stops from OTP |
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DATABASE_URL` | Yes | Neon PostgreSQL connection string |
+| `R2_ENDPOINT` | Yes | Cloudflare R2 endpoint URL |
+| `R2_ACCESS_KEY_ID` | Yes | R2 access key |
+| `R2_SECRET_ACCESS_KEY` | Yes | R2 secret key |
+| `R2_BUCKET` | No | R2 bucket name (default: `porto-move`) |
+| `COLLECT_INTERVAL_S` | No | Collection interval in seconds (default: `30`) |
+| `FIWARE_URL` | No | FIWARE broker URL (has default) |
+| `OTP_URL` | No | OTP GraphQL endpoint (has default) |
+| `DATE` | No | Override date for `aggregate-daily` backfills (YYYY-MM-DD) |
+
+## Testing
+
+```bash
+pytest
+```
+
+## Docker
+
+```bash
+docker build -f worker-py/Dockerfile -t portomove-worker .
+docker run --env-file .env portomove-worker
+```

--- a/worker-py/pyproject.toml
+++ b/worker-py/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "portomove-worker"
+version = "2.0.0"
+requires-python = ">=3.12"
+dependencies = [
+    "duckdb==1.5.3",
+    "httpx>=0.28",
+    "boto3>=1.35",
+]
+
+[project.scripts]
+worker = "worker.main:main"

--- a/worker-py/pyproject.toml
+++ b/worker-py/pyproject.toml
@@ -4,9 +4,15 @@ version = "2.0.0"
 requires-python = ">=3.12"
 dependencies = [
     "duckdb==1.5.3",
-    "httpx>=0.28",
-    "boto3>=1.35",
+    "httpx==0.28.1",
+    "boto3==1.38.34",
 ]
+
+[project.optional-dependencies]
+dev = ["pytest==9.0.3"]
 
 [project.scripts]
 worker = "worker.main:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/worker-py/tests/test_worker.py
+++ b/worker-py/tests/test_worker.py
@@ -1,0 +1,164 @@
+import duckdb
+import pytest
+
+from worker.collector import _parse_entity, _unwrap_str, _unwrap_float, _unwrap_location
+
+
+class TestUnwrapHelpers:
+    def test_unwrap_str_value_obj(self):
+        assert _unwrap_str({"value": "500"}) == "500"
+
+    def test_unwrap_str_raw(self):
+        assert _unwrap_str("hello") == "hello"
+
+    def test_unwrap_str_none(self):
+        assert _unwrap_str(None) == ""
+
+    def test_unwrap_float_value_obj(self):
+        assert _unwrap_float({"value": 3.5}) == 3.5
+
+    def test_unwrap_float_raw(self):
+        assert _unwrap_float(42.0) == 42.0
+
+    def test_unwrap_float_none(self):
+        assert _unwrap_float(None) is None
+
+    def test_unwrap_location_nested(self):
+        raw = {"value": {"coordinates": [-8.6, 41.15]}}
+        lon, lat = _unwrap_location(raw)
+        assert lon == -8.6
+        assert lat == 41.15
+
+    def test_unwrap_location_direct(self):
+        raw = {"coordinates": [-8.6, 41.15]}
+        lon, lat = _unwrap_location(raw)
+        assert lon == -8.6
+        assert lat == 41.15
+
+    def test_unwrap_location_none(self):
+        assert _unwrap_location(None) == (None, None)
+
+    def test_unwrap_location_zeros(self):
+        assert _unwrap_location({"coordinates": [0, 0]}) == (None, None)
+
+
+class TestParseEntity:
+    def test_valid_entity(self):
+        entity = {
+            "id": "urn:ngsi-ld:Vehicle:stcp:500:1234",
+            "type": "Vehicle",
+            "location": {"value": {"coordinates": [-8.6, 41.15]}},
+            "routeShortName": {"value": "500"},
+            "speed": {"value": 25.0},
+        }
+        result = _parse_entity(entity)
+        assert result is not None
+        assert result["lat"] == 41.15
+        assert result["lon"] == -8.6
+        assert result["route"] == "500"
+        assert result["speed"] == 25.0
+
+    def test_missing_location(self):
+        entity = {"id": "test", "routeShortName": {"value": "500"}}
+        assert _parse_entity(entity) is None
+
+    def test_route_from_id(self):
+        entity = {
+            "id": "urn:ngsi-ld:Vehicle:stcp:205:9999",
+            "location": {"value": {"coordinates": [-8.6, 41.15]}},
+        }
+        result = _parse_entity(entity)
+        assert result is not None
+        assert result["route"] == "205"
+
+    def test_annotations_direction(self):
+        entity = {
+            "id": "urn:ngsi-ld:Vehicle:stcp:500:1234",
+            "location": {"value": {"coordinates": [-8.6, 41.15]}},
+            "routeShortName": {"value": "500"},
+            "annotations": {"value": ["stcp:sentido:1", "stcp:nr_viagem:T42"]},
+        }
+        result = _parse_entity(entity)
+        assert result["directionId"] == 1
+        assert result["tripId"] == "T42"
+
+
+class TestAggregateTripReconstruction:
+    """Test trip reconstruction SQL logic using in-memory DuckDB."""
+
+    def test_trip_split_on_gap(self):
+        db = duckdb.connect(":memory:")
+        # Create positions with a >10min gap
+        db.execute("""
+            CREATE TABLE pos AS SELECT * FROM (VALUES
+                ('2024-01-01 08:00:00'::TIMESTAMP, 'v1', NULL, '500', NULL, 1::SMALLINT, 41.15, -8.6, 20.0::FLOAT),
+                ('2024-01-01 08:01:00'::TIMESTAMP, 'v1', NULL, '500', NULL, 1::SMALLINT, 41.16, -8.6, 22.0::FLOAT),
+                ('2024-01-01 08:02:00'::TIMESTAMP, 'v1', NULL, '500', NULL, 1::SMALLINT, 41.17, -8.6, 18.0::FLOAT),
+                ('2024-01-01 08:20:00'::TIMESTAMP, 'v1', NULL, '500', NULL, 1::SMALLINT, 41.18, -8.6, 25.0::FLOAT),
+                ('2024-01-01 08:21:00'::TIMESTAMP, 'v1', NULL, '500', NULL, 1::SMALLINT, 41.19, -8.6, 23.0::FLOAT),
+                ('2024-01-01 08:22:00'::TIMESTAMP, 'v1', NULL, '500', NULL, 1::SMALLINT, 41.20, -8.6, 21.0::FLOAT)
+            ) AS t(recorded_at, vehicle_id, vehicle_num, route, trip_id, direction_id, lat, lon, speed)
+        """)
+
+        db.execute("""
+            CREATE TABLE trips AS
+            WITH ordered AS (
+                SELECT *,
+                    LAG(recorded_at) OVER (PARTITION BY vehicle_id, route, direction_id ORDER BY recorded_at) AS prev_at
+                FROM pos
+            ),
+            trip_boundaries AS (
+                SELECT *,
+                    SUM(CASE WHEN prev_at IS NULL OR EPOCH(recorded_at - prev_at) > 600 THEN 1 ELSE 0 END)
+                        OVER (PARTITION BY vehicle_id, route, direction_id ORDER BY recorded_at) AS trip_num
+                FROM ordered
+            )
+            SELECT
+                vehicle_id, route, direction_id, trip_num,
+                MIN(recorded_at) AS started_at,
+                MAX(recorded_at) AS ended_at,
+                COUNT(*) AS positions,
+                ROUND(AVG(CASE WHEN speed > 0 THEN speed END), 1) AS avg_speed
+            FROM trip_boundaries
+            GROUP BY vehicle_id, route, direction_id, trip_num
+            HAVING COUNT(*) >= 3
+        """)
+
+        trips = db.execute("SELECT * FROM trips ORDER BY started_at").fetchall()
+        assert len(trips) == 2
+        assert trips[0][6] == 3  # first trip: 3 positions
+        assert trips[1][6] == 3  # second trip: 3 positions
+
+    def test_single_trip_no_gap(self):
+        db = duckdb.connect(":memory:")
+        db.execute("""
+            CREATE TABLE pos AS SELECT * FROM (VALUES
+                ('2024-01-01 08:00:00'::TIMESTAMP, 'v1', NULL, '500', NULL, 1::SMALLINT, 41.15, -8.6, 20.0::FLOAT),
+                ('2024-01-01 08:01:00'::TIMESTAMP, 'v1', NULL, '500', NULL, 1::SMALLINT, 41.16, -8.6, 22.0::FLOAT),
+                ('2024-01-01 08:02:00'::TIMESTAMP, 'v1', NULL, '500', NULL, 1::SMALLINT, 41.17, -8.6, 18.0::FLOAT),
+                ('2024-01-01 08:03:00'::TIMESTAMP, 'v1', NULL, '500', NULL, 1::SMALLINT, 41.18, -8.6, 25.0::FLOAT)
+            ) AS t(recorded_at, vehicle_id, vehicle_num, route, trip_id, direction_id, lat, lon, speed)
+        """)
+
+        db.execute("""
+            CREATE TABLE trips AS
+            WITH ordered AS (
+                SELECT *,
+                    LAG(recorded_at) OVER (PARTITION BY vehicle_id, route, direction_id ORDER BY recorded_at) AS prev_at
+                FROM pos
+            ),
+            trip_boundaries AS (
+                SELECT *,
+                    SUM(CASE WHEN prev_at IS NULL OR EPOCH(recorded_at - prev_at) > 600 THEN 1 ELSE 0 END)
+                        OVER (PARTITION BY vehicle_id, route, direction_id ORDER BY recorded_at) AS trip_num
+                FROM ordered
+            )
+            SELECT COUNT(*) AS positions
+            FROM trip_boundaries
+            GROUP BY vehicle_id, route, direction_id, trip_num
+            HAVING COUNT(*) >= 3
+        """)
+
+        trips = db.execute("SELECT * FROM trips").fetchall()
+        assert len(trips) == 1
+        assert trips[0][0] == 4

--- a/worker-py/worker/aggregate.py
+++ b/worker-py/worker/aggregate.py
@@ -1,0 +1,160 @@
+"""Aggregate daily job: reads R2 snapshots via DuckDB httpfs, processes, writes to Neon."""
+import logging
+import os
+import time
+from datetime import datetime, timezone, timedelta
+
+from worker.db import get_duck, attach_neon, r2_bucket_url
+from worker.r2 import get_r2, BUCKET
+
+log = logging.getLogger("worker")
+
+
+def run_aggregate_daily():
+    start = time.time()
+
+    # Support DATE env var for backfills
+    date_str = os.getenv("DATE")
+    if date_str:
+        yesterday = datetime.strptime(date_str, "%Y-%m-%d").date()
+    else:
+        yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).date()
+
+    date_str = yesterday.isoformat()
+    date_path = yesterday.strftime("%Y/%m/%d")
+    log.info(f"[aggregate] Starting for {date_str}")
+
+    # Check if snapshots exist
+    r2 = get_r2()
+    prefix = f"snapshots/{date_path}/"
+    resp = r2.list_objects_v2(Bucket=BUCKET, Prefix=prefix, MaxKeys=1)
+    if not resp.get("Contents"):
+        log.info(f"[aggregate] No snapshots for {date_str}")
+        return
+
+    db = get_duck()
+    attach_neon(db)
+
+    bucket_url = r2_bucket_url()
+    s3_path = f"{bucket_url}/{prefix}*.json"
+
+    # Load all snapshots into a local table via httpfs
+    log.info(f"[aggregate] Reading snapshots from {s3_path}")
+    db.execute(f"""
+        CREATE TABLE positions AS
+        SELECT
+            unnest(positions) AS p,
+            recordedAt::TIMESTAMP AS recorded_at
+        FROM read_json('{s3_path}', format='auto', union_by_name=true)
+    """)
+    db.execute("""
+        CREATE TABLE pos AS
+        SELECT
+            recorded_at,
+            p.vehicleId AS vehicle_id,
+            p.vehicleNum AS vehicle_num,
+            p.route AS route,
+            p.tripId AS trip_id,
+            p.directionId::SMALLINT AS direction_id,
+            p.lat::DOUBLE AS lat,
+            p.lon::DOUBLE AS lon,
+            p.speed::FLOAT AS speed
+        FROM positions
+        WHERE p.route IS NOT NULL AND p.route != ''
+    """)
+    db.execute("DROP TABLE positions")
+
+    total = db.execute("SELECT count(*) FROM pos").fetchone()[0]
+    log.info(f"[aggregate] Loaded {total} positions")
+
+    # Trip reconstruction: group by vehicle+route+direction, split on >10min gaps
+    db.execute("""
+        CREATE TABLE trips AS
+        WITH ordered AS (
+            SELECT *,
+                ROW_NUMBER() OVER (PARTITION BY vehicle_id, route, direction_id ORDER BY recorded_at) AS rn,
+                LAG(recorded_at) OVER (PARTITION BY vehicle_id, route, direction_id ORDER BY recorded_at) AS prev_at
+            FROM pos
+        ),
+        trip_boundaries AS (
+            SELECT *,
+                SUM(CASE WHEN prev_at IS NULL OR EPOCH(recorded_at - prev_at) > 600 THEN 1 ELSE 0 END)
+                    OVER (PARTITION BY vehicle_id, route, direction_id ORDER BY recorded_at) AS trip_num
+            FROM ordered
+        )
+        SELECT
+            vehicle_id,
+            FIRST(vehicle_num) AS vehicle_num,
+            route,
+            FIRST(trip_id) AS trip_id,
+            direction_id,
+            MIN(recorded_at) AS started_at,
+            MAX(recorded_at) AS ended_at,
+            EXTRACT(EPOCH FROM MAX(recorded_at) - MIN(recorded_at))::INTEGER AS runtime_secs,
+            COUNT(*) AS positions,
+            ROUND(AVG(CASE WHEN speed > 0 THEN speed END), 1) AS avg_speed
+        FROM trip_boundaries
+        GROUP BY vehicle_id, route, direction_id, trip_num
+        HAVING COUNT(*) >= 3
+    """)
+
+    trip_count = db.execute("SELECT count(*) FROM trips").fetchone()[0]
+    log.info(f"[aggregate] Reconstructed {trip_count} trips")
+
+    # Route performance daily
+    db.execute("""
+        CREATE TABLE route_perf AS
+        SELECT
+            route,
+            direction_id,
+            COUNT(*) AS trips_observed,
+            ROUND(AVG(runtime_secs), 0)::INTEGER AS avg_runtime_secs,
+            ROUND(AVG(avg_speed), 1) AS avg_commercial_speed
+        FROM trips
+        WHERE runtime_secs > 60
+        GROUP BY route, direction_id
+    """)
+
+    # Network summary
+    db.execute("""
+        CREATE TABLE network_summary AS
+        SELECT
+            COUNT(DISTINCT vehicle_id) AS active_vehicles,
+            COUNT(*) AS total_trips,
+            ROUND(AVG(avg_speed), 1) AS avg_commercial_speed
+        FROM trips
+    """)
+
+    # Write to Neon in a single transaction
+    log.info("[aggregate] Writing to Neon...")
+    db.execute(f"CALL postgres_execute('neon', 'BEGIN')")
+    db.execute(f"CALL postgres_execute('neon', 'DELETE FROM \"TripLog\" WHERE date = ''{date_str}''')")
+    db.execute(f"""
+        INSERT INTO neon."TripLog" (date, "vehicleId", "vehicleNum", route, "tripId", "directionId", "startedAt", "endedAt", "runtimeSecs", positions, "avgSpeed")
+        SELECT '{date_str}'::DATE, vehicle_id, vehicle_num, route, trip_id, direction_id, started_at, ended_at, runtime_secs, positions, avg_speed
+        FROM trips
+    """)
+
+    db.execute(f"CALL postgres_execute('neon', 'DELETE FROM \"RoutePerformanceDaily\" WHERE date = ''{date_str}''')")
+    db.execute(f"""
+        INSERT INTO neon."RoutePerformanceDaily" (date, route, "directionId", "tripsObserved", "avgRuntimeSecs", "avgCommercialSpeed")
+        SELECT '{date_str}'::DATE, route, direction_id, trips_observed, avg_runtime_secs, avg_commercial_speed
+        FROM route_perf
+    """)
+
+    # Network summary upsert via postgres_execute
+    ns = db.execute("SELECT * FROM network_summary").fetchone()
+    db.execute(f"""CALL postgres_execute('neon', '
+        INSERT INTO "NetworkSummaryDaily" (date, "activeVehicles", "totalTrips", "avgCommercialSpeed", "positionsCollected")
+        VALUES (''{date_str}'', {ns[0]}, {ns[1]}, {ns[2] or 'NULL'}, {total})
+        ON CONFLICT (date) DO UPDATE SET
+            "activeVehicles" = EXCLUDED."activeVehicles",
+            "totalTrips" = EXCLUDED."totalTrips",
+            "avgCommercialSpeed" = EXCLUDED."avgCommercialSpeed",
+            "positionsCollected" = EXCLUDED."positionsCollected"
+    ')""")
+
+    db.execute(f"CALL postgres_execute('neon', 'COMMIT')")
+
+    elapsed = time.time() - start
+    log.info(f"[aggregate] Complete for {date_str}: {total} positions, {trip_count} trips in {elapsed:.1f}s")

--- a/worker-py/worker/aggregate.py
+++ b/worker-py/worker/aggregate.py
@@ -128,33 +128,37 @@ def run_aggregate_daily():
     # Write to Neon in a single transaction
     log.info("[aggregate] Writing to Neon...")
     db.execute(f"CALL postgres_execute('neon', 'BEGIN')")
-    db.execute(f"CALL postgres_execute('neon', 'DELETE FROM \"TripLog\" WHERE date = ''{date_str}''')")
-    db.execute(f"""
-        INSERT INTO neon."TripLog" (date, "vehicleId", "vehicleNum", route, "tripId", "directionId", "startedAt", "endedAt", "runtimeSecs", positions, "avgSpeed")
-        SELECT '{date_str}'::DATE, vehicle_id, vehicle_num, route, trip_id, direction_id, started_at, ended_at, runtime_secs, positions, avg_speed
-        FROM trips
-    """)
+    try:
+        db.execute(f"CALL postgres_execute('neon', 'DELETE FROM \"TripLog\" WHERE date = ''{date_str}''')")
+        db.execute(f"""
+            INSERT INTO neon."TripLog" (date, "vehicleId", "vehicleNum", route, "tripId", "directionId", "startedAt", "endedAt", "runtimeSecs", positions, "avgSpeed")
+            SELECT '{date_str}'::DATE, vehicle_id, vehicle_num, route, trip_id, direction_id, started_at, ended_at, runtime_secs, positions, avg_speed
+            FROM trips
+        """)
 
-    db.execute(f"CALL postgres_execute('neon', 'DELETE FROM \"RoutePerformanceDaily\" WHERE date = ''{date_str}''')")
-    db.execute(f"""
-        INSERT INTO neon."RoutePerformanceDaily" (date, route, "directionId", "tripsObserved", "avgRuntimeSecs", "avgCommercialSpeed")
-        SELECT '{date_str}'::DATE, route, direction_id, trips_observed, avg_runtime_secs, avg_commercial_speed
-        FROM route_perf
-    """)
+        db.execute(f"CALL postgres_execute('neon', 'DELETE FROM \"RoutePerformanceDaily\" WHERE date = ''{date_str}''')")
+        db.execute(f"""
+            INSERT INTO neon."RoutePerformanceDaily" (date, route, "directionId", "tripsObserved", "avgRuntimeSecs", "avgCommercialSpeed")
+            SELECT '{date_str}'::DATE, route, direction_id, trips_observed, avg_runtime_secs, avg_commercial_speed
+            FROM route_perf
+        """)
 
-    # Network summary upsert via postgres_execute
-    ns = db.execute("SELECT * FROM network_summary").fetchone()
-    db.execute(f"""CALL postgres_execute('neon', '
-        INSERT INTO "NetworkSummaryDaily" (date, "activeVehicles", "totalTrips", "avgCommercialSpeed", "positionsCollected")
-        VALUES (''{date_str}'', {ns[0]}, {ns[1]}, {ns[2] or 'NULL'}, {total})
-        ON CONFLICT (date) DO UPDATE SET
-            "activeVehicles" = EXCLUDED."activeVehicles",
-            "totalTrips" = EXCLUDED."totalTrips",
-            "avgCommercialSpeed" = EXCLUDED."avgCommercialSpeed",
-            "positionsCollected" = EXCLUDED."positionsCollected"
-    ')""")
+        # Network summary upsert via postgres_execute
+        ns = db.execute("SELECT * FROM network_summary").fetchone()
+        db.execute(f"""CALL postgres_execute('neon', '
+            INSERT INTO "NetworkSummaryDaily" (date, "activeVehicles", "totalTrips", "avgCommercialSpeed", "positionsCollected")
+            VALUES (''{date_str}'', {ns[0]}, {ns[1]}, {ns[2] or "NULL"}, {total})
+            ON CONFLICT (date) DO UPDATE SET
+                "activeVehicles" = EXCLUDED."activeVehicles",
+                "totalTrips" = EXCLUDED."totalTrips",
+                "avgCommercialSpeed" = EXCLUDED."avgCommercialSpeed",
+                "positionsCollected" = EXCLUDED."positionsCollected"
+        ')""")
 
-    db.execute(f"CALL postgres_execute('neon', 'COMMIT')")
+        db.execute(f"CALL postgres_execute('neon', 'COMMIT')")
+    except Exception:
+        db.execute(f"CALL postgres_execute('neon', 'ROLLBACK')")
+        raise
 
     elapsed = time.time() - start
     log.info(f"[aggregate] Complete for {date_str}: {total} positions, {trip_count} trips in {elapsed:.1f}s")

--- a/worker-py/worker/aggregate.py
+++ b/worker-py/worker/aggregate.py
@@ -1,4 +1,4 @@
-"""Aggregate daily job: reads R2 snapshots via DuckDB httpfs, processes, writes to Neon."""
+"""Aggregate daily job: reads Parquet/JSON from R2, processes in DuckDB, writes results to R2 Parquet + Neon."""
 import logging
 import os
 import time
@@ -10,10 +10,9 @@ from worker.r2 import get_r2, BUCKET
 log = logging.getLogger("worker")
 
 
-def run_aggregate_daily():
+def run_aggregate_daily() -> None:
     start = time.time()
 
-    # Support DATE env var for backfills
     date_str = os.getenv("DATE")
     if date_str:
         yesterday = datetime.strptime(date_str, "%Y-%m-%d").date()
@@ -22,65 +21,70 @@ def run_aggregate_daily():
 
     date_str = yesterday.isoformat()
     date_path = yesterday.strftime("%Y/%m/%d")
-    log.info(f"[aggregate] Starting for {date_str}")
-
-    # Check if snapshots exist
-    r2 = get_r2()
-    prefix = f"snapshots/{date_path}/"
-    resp = r2.list_objects_v2(Bucket=BUCKET, Prefix=prefix, MaxKeys=1)
-    if not resp.get("Contents"):
-        log.info(f"[aggregate] No snapshots for {date_str}")
-        return
+    log.info("[aggregate] Starting for %s", date_str)
 
     db = get_duck()
-    attach_neon(db)
-
     bucket_url = r2_bucket_url()
-    s3_path = f"{bucket_url}/{prefix}*.json"
 
-    # Load all snapshots into a local table via httpfs
-    log.info(f"[aggregate] Reading snapshots from {s3_path}")
-    db.execute(f"""
-        CREATE TABLE positions AS
-        SELECT
-            unnest(positions) AS p,
-            recordedAt::TIMESTAMP AS recorded_at
-        FROM read_json('{s3_path}', format='auto', union_by_name=true)
-    """)
-    db.execute("""
-        CREATE TABLE pos AS
-        SELECT
-            recorded_at,
-            p.vehicleId AS vehicle_id,
-            p.vehicleNum AS vehicle_num,
-            p.route AS route,
-            p.tripId AS trip_id,
-            p.directionId::SMALLINT AS direction_id,
-            p.lat::DOUBLE AS lat,
-            p.lon::DOUBLE AS lon,
-            p.speed::FLOAT AS speed
-        FROM positions
-        WHERE p.route IS NOT NULL AND p.route != ''
-    """)
-    db.execute("DROP TABLE positions")
+    # Prefer Parquet (written by archive job at 02:00) over raw JSON
+    parquet_path = f"{bucket_url}/positions/{date_path}.parquet"
+    json_path = f"{bucket_url}/snapshots/{date_path}/*.json"
+
+    try:
+        db.execute(f"""
+            CREATE TABLE pos AS
+            SELECT recorded_at::TIMESTAMP AS recorded_at, vehicle_id, vehicle_num,
+                   route, trip_id, direction_id, lat, lon, speed
+            FROM read_parquet('{parquet_path}')
+            WHERE route IS NOT NULL AND route != ''
+            ORDER BY vehicle_id, route, direction_id, recorded_at
+        """)
+        log.info("[aggregate] Reading from Parquet archive")
+    except Exception:
+        # Fallback to JSON if Parquet not yet available
+        log.info("[aggregate] Parquet not found, reading JSON snapshots")
+        r2 = get_r2()
+        prefix = f"snapshots/{date_path}/"
+        resp = r2.list_objects_v2(Bucket=BUCKET, Prefix=prefix, MaxKeys=1)
+        if not resp.get("Contents"):
+            log.info("[aggregate] No snapshots for %s", date_str)
+            return
+        db.execute(f"""
+            CREATE TABLE pos AS
+            SELECT recorded_at, vehicle_id, vehicle_num, route, trip_id, direction_id, lat, lon, speed
+            FROM (
+                SELECT p.vehicleId AS vehicle_id, p.vehicleNum AS vehicle_num,
+                       p.route AS route, p.tripId AS trip_id,
+                       p.directionId::SMALLINT AS direction_id,
+                       p.lat::DOUBLE AS lat, p.lon::DOUBLE AS lon,
+                       p.speed::FLOAT AS speed,
+                       recordedAt::TIMESTAMP AS recorded_at
+                FROM (
+                    SELECT unnest(positions) AS p, recordedAt
+                    FROM read_json('{json_path}', format='auto', union_by_name=true)
+                )
+            )
+            WHERE route IS NOT NULL AND route != ''
+            ORDER BY vehicle_id, route, direction_id, recorded_at
+        """)
 
     total = db.execute("SELECT count(*) FROM pos").fetchone()[0]
-    log.info(f"[aggregate] Loaded {total} positions")
+    log.info("[aggregate] Loaded %d positions", total)
 
-    # Trip reconstruction: group by vehicle+route+direction, split on >10min gaps
+    if total == 0:
+        return
+
+    # Trip reconstruction (pre-sorted data = streaming window pass)
     db.execute("""
         CREATE TABLE trips AS
-        WITH ordered AS (
+        WITH trip_boundaries AS (
             SELECT *,
-                ROW_NUMBER() OVER (PARTITION BY vehicle_id, route, direction_id ORDER BY recorded_at) AS rn,
-                LAG(recorded_at) OVER (PARTITION BY vehicle_id, route, direction_id ORDER BY recorded_at) AS prev_at
+                SUM(CASE WHEN
+                    LAG(recorded_at) OVER w IS NULL OR
+                    EPOCH(recorded_at - LAG(recorded_at) OVER w) > 600
+                THEN 1 ELSE 0 END) OVER w AS trip_num
             FROM pos
-        ),
-        trip_boundaries AS (
-            SELECT *,
-                SUM(CASE WHEN prev_at IS NULL OR EPOCH(recorded_at - prev_at) > 600 THEN 1 ELSE 0 END)
-                    OVER (PARTITION BY vehicle_id, route, direction_id ORDER BY recorded_at) AS trip_num
-            FROM ordered
+            WINDOW w AS (PARTITION BY vehicle_id, route, direction_id ORDER BY recorded_at)
         )
         SELECT
             vehicle_id,
@@ -99,9 +103,9 @@ def run_aggregate_daily():
     """)
 
     trip_count = db.execute("SELECT count(*) FROM trips").fetchone()[0]
-    log.info(f"[aggregate] Reconstructed {trip_count} trips")
+    log.info("[aggregate] Reconstructed %d trips", trip_count)
 
-    # Route performance daily
+    # Route performance
     db.execute("""
         CREATE TABLE route_perf AS
         SELECT
@@ -125,9 +129,20 @@ def run_aggregate_daily():
         FROM trips
     """)
 
-    # Write to Neon in a single transaction
-    log.info("[aggregate] Writing to Neon...")
-    db.execute(f"CALL postgres_execute('neon', 'BEGIN')")
+    # Write analytics to R2 as Parquet (zero Neon compute for reads)
+    log.info("[aggregate] Writing analytics Parquet to R2...")
+    db.execute(f"""
+        COPY (SELECT '{date_str}'::DATE AS date, * FROM trips)
+        TO '{bucket_url}/analytics/trips/{date_str}.parquet' (FORMAT PARQUET, COMPRESSION ZSTD)
+    """)
+    db.execute(f"""
+        COPY (SELECT '{date_str}'::DATE AS date, * FROM route_perf)
+        TO '{bucket_url}/analytics/route_perf/{date_str}.parquet' (FORMAT PARQUET, COMPRESSION ZSTD)
+    """)
+
+    # Also write to Neon for backward compatibility (minimal compute)
+    attach_neon(db)
+    db.execute("CALL postgres_execute('neon', 'BEGIN')")
     try:
         db.execute(f"CALL postgres_execute('neon', 'DELETE FROM \"TripLog\" WHERE date = ''{date_str}''')")
         db.execute(f"""
@@ -143,11 +158,11 @@ def run_aggregate_daily():
             FROM route_perf
         """)
 
-        # Network summary upsert via postgres_execute
         ns = db.execute("SELECT * FROM network_summary").fetchone()
+        avg_speed_val = ns[2] if ns[2] is not None else "NULL"
         db.execute(f"""CALL postgres_execute('neon', '
             INSERT INTO "NetworkSummaryDaily" (date, "activeVehicles", "totalTrips", "avgCommercialSpeed", "positionsCollected")
-            VALUES (''{date_str}'', {ns[0]}, {ns[1]}, {ns[2] or "NULL"}, {total})
+            VALUES (''{date_str}'', {ns[0]}, {ns[1]}, {avg_speed_val}, {total})
             ON CONFLICT (date) DO UPDATE SET
                 "activeVehicles" = EXCLUDED."activeVehicles",
                 "totalTrips" = EXCLUDED."totalTrips",
@@ -155,10 +170,10 @@ def run_aggregate_daily():
                 "positionsCollected" = EXCLUDED."positionsCollected"
         ')""")
 
-        db.execute(f"CALL postgres_execute('neon', 'COMMIT')")
+        db.execute("CALL postgres_execute('neon', 'COMMIT')")
     except Exception:
-        db.execute(f"CALL postgres_execute('neon', 'ROLLBACK')")
+        db.execute("CALL postgres_execute('neon', 'ROLLBACK')")
         raise
 
     elapsed = time.time() - start
-    log.info(f"[aggregate] Complete for {date_str}: {total} positions, {trip_count} trips in {elapsed:.1f}s")
+    log.info("[aggregate] Complete for %s: %d positions, %d trips in %.1fs", date_str, total, trip_count, elapsed)

--- a/worker-py/worker/archive.py
+++ b/worker-py/worker/archive.py
@@ -1,0 +1,63 @@
+"""Archive positions: convert yesterday's R2 JSON snapshots to a single Parquet file."""
+import logging
+import time
+from datetime import datetime, timezone, timedelta
+
+from worker.db import get_duck, r2_bucket_url
+from worker.r2 import get_r2, BUCKET
+
+log = logging.getLogger("worker")
+
+
+def run_archive_positions():
+    start = time.time()
+    yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).date()
+    date_path = yesterday.strftime("%Y/%m/%d")
+    parquet_key = f"positions/{yesterday:%Y/%m/%d}.parquet"
+
+    r2 = get_r2()
+
+    # Check if already archived
+    try:
+        r2.head_object(Bucket=BUCKET, Key=parquet_key)
+        log.info(f"[archive] {parquet_key} already exists — skipping")
+        return
+    except r2.exceptions.ClientError:
+        pass
+
+    # Check if snapshots exist
+    prefix = f"snapshots/{date_path}/"
+    resp = r2.list_objects_v2(Bucket=BUCKET, Prefix=prefix, MaxKeys=1)
+    if not resp.get("Contents"):
+        log.info(f"[archive] No snapshots for {yesterday}")
+        return
+
+    db = get_duck()
+    bucket_url = r2_bucket_url()
+    r2_src = f"{bucket_url}/{prefix}*.json"
+
+    log.info(f"[archive] Reading {r2_src}")
+
+    # Read all snapshots and write as Parquet directly to R2
+    db.execute(f"""
+        COPY (
+            SELECT
+                recordedAt AS recorded_at,
+                p.vehicleId AS vehicle_id,
+                p.vehicleNum AS vehicle_num,
+                p.route AS route,
+                p.tripId AS trip_id,
+                p.directionId::SMALLINT AS direction_id,
+                p.lat::DOUBLE AS lat,
+                p.lon::DOUBLE AS lon,
+                p.speed::FLOAT AS speed,
+                p.heading::FLOAT AS heading
+            FROM (
+                SELECT unnest(positions) AS p, recordedAt
+                FROM read_json('{r2_src}', format='auto', union_by_name=true)
+            )
+        ) TO '{bucket_url}/{parquet_key}' (FORMAT PARQUET, COMPRESSION ZSTD)
+    """)
+
+    elapsed = time.time() - start
+    log.info(f"[archive] Wrote {parquet_key} in {elapsed:.1f}s")

--- a/worker-py/worker/archive.py
+++ b/worker-py/worker/archive.py
@@ -9,18 +9,18 @@ from worker.r2 import get_r2, BUCKET
 log = logging.getLogger("worker")
 
 
-def run_archive_positions():
+def run_archive_positions() -> None:
     start = time.time()
     yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).date()
     date_path = yesterday.strftime("%Y/%m/%d")
-    parquet_key = f"positions/{yesterday:%Y/%m/%d}.parquet"
+    parquet_key = f"positions/{date_path}.parquet"
 
     r2 = get_r2()
 
     # Check if already archived
     try:
         r2.head_object(Bucket=BUCKET, Key=parquet_key)
-        log.info(f"[archive] {parquet_key} already exists — skipping")
+        log.info("[archive] %s already exists — skipping", parquet_key)
         return
     except r2.exceptions.ClientError:
         pass
@@ -29,20 +29,21 @@ def run_archive_positions():
     prefix = f"snapshots/{date_path}/"
     resp = r2.list_objects_v2(Bucket=BUCKET, Prefix=prefix, MaxKeys=1)
     if not resp.get("Contents"):
-        log.info(f"[archive] No snapshots for {yesterday}")
+        log.info("[archive] No snapshots for %s", yesterday)
         return
 
     db = get_duck()
     bucket_url = r2_bucket_url()
     r2_src = f"{bucket_url}/{prefix}*.json"
 
-    log.info(f"[archive] Reading {r2_src}")
+    log.info("[archive] Reading %s", r2_src)
 
     # Read all snapshots and write as Parquet directly to R2
+    # Column names match what aggregate.py expects for direct Parquet read
     db.execute(f"""
         COPY (
             SELECT
-                recordedAt AS recorded_at,
+                recordedAt::TIMESTAMP AS recorded_at,
                 p.vehicleId AS vehicle_id,
                 p.vehicleNum AS vehicle_num,
                 p.route AS route,
@@ -60,4 +61,4 @@ def run_archive_positions():
     """)
 
     elapsed = time.time() - start
-    log.info(f"[archive] Wrote {parquet_key} in {elapsed:.1f}s")
+    log.info("[archive] Wrote %s in %.1fs", parquet_key, elapsed)

--- a/worker-py/worker/collector.py
+++ b/worker-py/worker/collector.py
@@ -1,0 +1,217 @@
+import json
+import re
+from datetime import datetime, timezone
+
+import httpx
+
+from worker.r2 import get_r2, BUCKET
+
+FIWARE_URL = "https://broker.fiware.urbanplatform.portodigital.pt/v2/entities?q=vehicleType==bus&limit=1000"
+_STCP_RE = re.compile(r"(?i)STCP\s+(\d+)")
+_ROUTE_PART_RE = re.compile(r"^[A-Za-z0-9]{1,4}$")
+
+# Rolling state for today.json
+_state = {
+    "date": "",
+    "positions_collected": 0,
+    "vehicles": set(),
+    "routes": set(),
+    "speed_sum": 0.0,
+    "speed_count": 0,
+    "hourly_speed_sum": [0.0] * 24,
+    "hourly_speed_count": [0] * 24,
+    "hourly_vehicles": [set() for _ in range(24)],
+    "hourly_routes": [set() for _ in range(24)],
+}
+
+
+def _reset_state(date: str):
+    _state["date"] = date
+    _state["positions_collected"] = 0
+    _state["vehicles"] = set()
+    _state["routes"] = set()
+    _state["speed_sum"] = 0.0
+    _state["speed_count"] = 0
+    _state["hourly_speed_sum"] = [0.0] * 24
+    _state["hourly_speed_count"] = [0] * 24
+    _state["hourly_vehicles"] = [set() for _ in range(24)]
+    _state["hourly_routes"] = [set() for _ in range(24)]
+
+
+def _unwrap_str(raw) -> str:
+    if raw is None:
+        return ""
+    if isinstance(raw, dict) and "value" in raw:
+        v = raw["value"]
+        return str(v) if v is not None else ""
+    if isinstance(raw, str):
+        return raw
+    return ""
+
+
+def _unwrap_float(raw):
+    if raw is None:
+        return None
+    if isinstance(raw, dict) and "value" in raw:
+        v = raw["value"]
+        return float(v) if v is not None else None
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    return None
+
+
+def _unwrap_location(raw):
+    if raw is None:
+        return None, None
+    coords = None
+    if isinstance(raw, dict):
+        if "value" in raw and isinstance(raw["value"], dict):
+            coords = raw["value"].get("coordinates")
+        elif "coordinates" in raw:
+            coords = raw["coordinates"]
+    if coords and len(coords) >= 2 and (coords[0] != 0 or coords[1] != 0):
+        return coords[0], coords[1]  # lon, lat
+    return None, None
+
+
+def _parse_entity(e: dict) -> dict | None:
+    lon, lat = _unwrap_location(e.get("location"))
+    if lon is None:
+        return None
+
+    # Route extraction
+    route = ""
+    for field in ("routeShortName", "route", "lineId", "line"):
+        route = _unwrap_str(e.get(field))
+        if route:
+            break
+
+    if not route:
+        vid = _unwrap_str(e.get("vehiclePlateIdentifier")) or _unwrap_str(e.get("vehicleNumber")) or _unwrap_str(e.get("name"))
+        if vid:
+            m = _STCP_RE.search(vid)
+            if m:
+                route = m.group(1)
+        if not route and e.get("id"):
+            parts = e["id"].split(":")
+            for p in parts[2:-1]:
+                if p and p not in ("Vehicle", "porto", "stcp") and _ROUTE_PART_RE.match(p):
+                    route = p
+                    break
+
+    # Direction and trip from annotations
+    direction_id = None
+    trip_id = None
+    annotations = e.get("annotations")
+    if isinstance(annotations, dict):
+        annotations = annotations.get("value", [])
+    if isinstance(annotations, list):
+        for ann in annotations:
+            if isinstance(ann, str):
+                if ann.startswith("stcp:sentido:"):
+                    try:
+                        direction_id = int(ann.split(":")[-1])
+                    except ValueError:
+                        pass
+                elif ann.startswith("stcp:nr_viagem:"):
+                    trip_id = ann.split(":", 2)[-1]
+
+    # Vehicle number
+    vehicle_num = ""
+    for field in ("vehiclePlateIdentifier", "vehicleNumber", "license_plate", "name"):
+        vehicle_num = _unwrap_str(e.get(field))
+        if vehicle_num:
+            break
+    if not vehicle_num and e.get("id"):
+        vehicle_num = e["id"].split(":")[-1]
+    if vehicle_num:
+        last = vehicle_num.split()[-1]
+        if last.isdigit():
+            vehicle_num = last
+
+    speed = _unwrap_float(e.get("speed"))
+    heading = _unwrap_float(e.get("heading")) or _unwrap_float(e.get("bearing"))
+
+    return {
+        "vehicleId": e.get("id", ""),
+        "vehicleNum": vehicle_num or None,
+        "route": route or None,
+        "tripId": trip_id,
+        "directionId": direction_id,
+        "lat": lat,
+        "lon": lon,
+        "speed": speed,
+        "heading": heading,
+    }
+
+
+def collect_positions() -> int:
+    now = datetime.now(timezone.utc)
+    r2 = get_r2()
+
+    resp = httpx.get(FIWARE_URL, headers={"User-Agent": "PortoMove-Collector/2.0", "Cache-Control": "no-cache"}, timeout=15)
+    resp.raise_for_status()
+    entities = resp.json()
+
+    if not entities:
+        raise RuntimeError("FIWARE returned empty response")
+
+    positions = []
+    for e in entities:
+        if not e.get("id"):
+            continue
+        p = _parse_entity(e)
+        if p:
+            positions.append(p)
+
+    if not positions:
+        return 0
+
+    snapshot = {"recordedAt": now.isoformat(), "positions": positions}
+    snapshot_json = json.dumps(snapshot, separators=(",", ":")).encode()
+
+    # Write snapshot to R2
+    key = f"snapshots/{now:%Y/%m/%d}/{now:%H%M%S}.json"
+    r2.put_object(Bucket=BUCKET, Key=key, Body=snapshot_json, ContentType="application/json")
+
+    # Update rolling state and write today.json
+    today = now.strftime("%Y-%m-%d")
+    if _state["date"] != today:
+        _reset_state(today)
+
+    h = now.hour
+    _state["positions_collected"] += len(positions)
+    for p in positions:
+        _state["vehicles"].add(p["vehicleId"])
+        if p["route"]:
+            _state["routes"].add(p["route"])
+        if p.get("speed") and p["speed"] > 0:
+            _state["speed_sum"] += p["speed"]
+            _state["speed_count"] += 1
+            _state["hourly_speed_sum"][h] += p["speed"]
+            _state["hourly_speed_count"][h] += 1
+        _state["hourly_vehicles"][h].add(p["vehicleId"])
+        if p["route"]:
+            _state["hourly_routes"][h].add(p["route"])
+
+    avg_speed = round(_state["speed_sum"] / _state["speed_count"], 1) if _state["speed_count"] else None
+    summary = {
+        "updatedAt": now.isoformat(),
+        "date": today,
+        "positionsCollected": _state["positions_collected"],
+        "activeVehicles": len(_state["vehicles"]),
+        "activeRoutes": len(_state["routes"]),
+        "avgSpeed": avg_speed,
+        "hourlySpeed": [
+            {"hour": i, "avgSpeed": round(_state["hourly_speed_sum"][i] / _state["hourly_speed_count"][i], 1) if _state["hourly_speed_count"][i] else None, "samples": _state["hourly_speed_count"][i]}
+            for i in range(24)
+        ],
+        "hourlyFleet": [
+            {"hour": i, "vehicles": len(_state["hourly_vehicles"][i]), "routes": len(_state["hourly_routes"][i])}
+            for i in range(24)
+        ],
+    }
+
+    r2.put_object(Bucket=BUCKET, Key="snapshots/today.json", Body=json.dumps(summary, separators=(",", ":")).encode(), ContentType="application/json")
+
+    return len(positions)

--- a/worker-py/worker/collector.py
+++ b/worker-py/worker/collector.py
@@ -1,17 +1,21 @@
+"""FIWARE bus position collector — fetches positions and writes snapshots to R2."""
 import json
+import os
 import re
 from datetime import datetime, timezone
+from typing import Any
 
 import httpx
 
 from worker.r2 import get_r2, BUCKET
 
-FIWARE_URL = "https://broker.fiware.urbanplatform.portodigital.pt/v2/entities?q=vehicleType==bus&limit=1000"
+FIWARE_URL = os.getenv("FIWARE_URL", "https://broker.fiware.urbanplatform.portodigital.pt/v2/entities?q=vehicleType==bus&limit=1000")
 _STCP_RE = re.compile(r"(?i)STCP\s+(\d+)")
 _ROUTE_PART_RE = re.compile(r"^[A-Za-z0-9]{1,4}$")
+_HTTP = httpx.Client(timeout=15, transport=httpx.HTTPTransport(retries=2))
 
 # Rolling state for today.json
-_state = {
+_state: dict[str, Any] = {
     "date": "",
     "positions_collected": 0,
     "vehicles": set(),
@@ -25,7 +29,7 @@ _state = {
 }
 
 
-def _reset_state(date: str):
+def _reset_state(date: str) -> None:
     _state["date"] = date
     _state["positions_collected"] = 0
     _state["vehicles"] = set()
@@ -38,7 +42,8 @@ def _reset_state(date: str):
     _state["hourly_routes"] = [set() for _ in range(24)]
 
 
-def _unwrap_str(raw) -> str:
+def _unwrap_str(raw: Any) -> str:
+    """Extract string from FIWARE attribute (value object or raw)."""
     if raw is None:
         return ""
     if isinstance(raw, dict) and "value" in raw:
@@ -49,7 +54,8 @@ def _unwrap_str(raw) -> str:
     return ""
 
 
-def _unwrap_float(raw):
+def _unwrap_float(raw: Any) -> float | None:
+    """Extract float from FIWARE attribute."""
     if raw is None:
         return None
     if isinstance(raw, dict) and "value" in raw:
@@ -60,7 +66,8 @@ def _unwrap_float(raw):
     return None
 
 
-def _unwrap_location(raw):
+def _unwrap_location(raw: Any) -> tuple[float | None, float | None]:
+    """Extract (lon, lat) from FIWARE location attribute."""
     if raw is None:
         return None, None
     coords = None
@@ -70,11 +77,12 @@ def _unwrap_location(raw):
         elif "coordinates" in raw:
             coords = raw["coordinates"]
     if coords and len(coords) >= 2 and (coords[0] != 0 or coords[1] != 0):
-        return coords[0], coords[1]  # lon, lat
+        return coords[0], coords[1]
     return None, None
 
 
-def _parse_entity(e: dict) -> dict | None:
+def _parse_entity(e: dict[str, Any]) -> dict[str, Any] | None:
+    """Parse a FIWARE entity into a position dict. Returns None if invalid."""
     lon, lat = _unwrap_location(e.get("location"))
     if lon is None:
         return None
@@ -100,8 +108,8 @@ def _parse_entity(e: dict) -> dict | None:
                     break
 
     # Direction and trip from annotations
-    direction_id = None
-    trip_id = None
+    direction_id: int | None = None
+    trip_id: str | None = None
     annotations = e.get("annotations")
     if isinstance(annotations, dict):
         annotations = annotations.get("value", [])
@@ -146,23 +154,18 @@ def _parse_entity(e: dict) -> dict | None:
 
 
 def collect_positions() -> int:
+    """Fetch positions from FIWARE and write snapshot to R2. Returns count."""
     now = datetime.now(timezone.utc)
     r2 = get_r2()
 
-    resp = httpx.get(FIWARE_URL, headers={"User-Agent": "PortoMove-Collector/2.0", "Cache-Control": "no-cache"}, timeout=15)
+    resp = _HTTP.get(FIWARE_URL, headers={"User-Agent": "PortoMove-Collector/2.0", "Cache-Control": "no-cache"})
     resp.raise_for_status()
     entities = resp.json()
 
     if not entities:
         raise RuntimeError("FIWARE returned empty response")
 
-    positions = []
-    for e in entities:
-        if not e.get("id"):
-            continue
-        p = _parse_entity(e)
-        if p:
-            positions.append(p)
+    positions = [p for e in entities if e.get("id") and (p := _parse_entity(e)) is not None]
 
     if not positions:
         return 0
@@ -170,11 +173,10 @@ def collect_positions() -> int:
     snapshot = {"recordedAt": now.isoformat(), "positions": positions}
     snapshot_json = json.dumps(snapshot, separators=(",", ":")).encode()
 
-    # Write snapshot to R2
     key = f"snapshots/{now:%Y/%m/%d}/{now:%H%M%S}.json"
     r2.put_object(Bucket=BUCKET, Key=key, Body=snapshot_json, ContentType="application/json")
 
-    # Update rolling state and write today.json
+    # Update rolling state
     today = now.strftime("%Y-%m-%d")
     if _state["date"] != today:
         _reset_state(today)

--- a/worker-py/worker/db.py
+++ b/worker-py/worker/db.py
@@ -1,0 +1,39 @@
+import os
+import duckdb
+
+
+def get_duck(memory_limit: str = "256MB") -> duckdb.DuckDBPyConnection:
+    """Create a DuckDB connection with postgres + httpfs extensions."""
+    db = duckdb.connect(":memory:", config={"memory_limit": memory_limit, "threads": "1"})
+
+    db.execute("INSTALL postgres; LOAD postgres;")
+    db.execute("INSTALL httpfs; LOAD httpfs;")
+
+    # Configure R2 access using native R2 secret type
+    # Extract account ID from endpoint: https://<account_id>.r2.cloudflarestorage.com
+    endpoint = os.environ["R2_ENDPOINT"]
+    account_id = endpoint.replace("https://", "").split(".")[0]
+    db.execute(f"""
+        CREATE SECRET r2 (
+            TYPE r2,
+            KEY_ID '{os.environ["R2_ACCESS_KEY_ID"]}',
+            SECRET '{os.environ["R2_SECRET_ACCESS_KEY"]}',
+            ACCOUNT_ID '{account_id}',
+            REGION 'auto'
+        )
+    """)
+
+    return db
+
+
+def r2_bucket_url() -> str:
+    """Return the r2:// URL prefix for the bucket."""
+    return f"r2://{os.getenv('R2_BUCKET', 'porto-move')}"
+
+
+def attach_neon(db: duckdb.DuckDBPyConnection):
+    """Attach Neon postgres database."""
+    url = os.environ["DATABASE_URL"]
+    url = url.replace("&channel_binding=require", "").replace("?channel_binding=require&", "?").replace("?channel_binding=require", "")
+    db.execute("SET pg_connection_limit = 2")
+    db.execute(f"ATTACH '{url}' AS neon (TYPE postgres, SCHEMA 'public')")

--- a/worker-py/worker/jobs.py
+++ b/worker-py/worker/jobs.py
@@ -1,11 +1,22 @@
+"""Job registry for scheduled tasks."""
+from typing import Callable, TypedDict
+
 from worker.aggregate import run_aggregate_daily
 from worker.archive import run_archive_positions
 from worker.schedule import run_snapshot_schedule, run_cleanup_positions, run_refresh_segments
 
-JOBS = [
+
+class Job(TypedDict, total=False):
+    name: str
+    hour: int
+    day_of_week: int | None
+    fn: Callable[[], None]
+
+
+JOBS: list[Job] = [
     {"name": "snapshot-schedule", "hour": 1, "fn": run_snapshot_schedule},
     {"name": "aggregate-daily", "hour": 3, "fn": run_aggregate_daily},
     {"name": "archive-positions", "hour": 3, "fn": run_archive_positions},
     {"name": "cleanup-positions", "hour": 4, "fn": run_cleanup_positions},
-    {"name": "refresh-segments", "hour": 5, "day_of_week": 0, "fn": run_refresh_segments},  # Monday
+    {"name": "refresh-segments", "hour": 5, "day_of_week": 0, "fn": run_refresh_segments},
 ]

--- a/worker-py/worker/jobs.py
+++ b/worker-py/worker/jobs.py
@@ -1,0 +1,11 @@
+from worker.aggregate import run_aggregate_daily
+from worker.archive import run_archive_positions
+from worker.schedule import run_snapshot_schedule, run_cleanup_positions, run_refresh_segments
+
+JOBS = [
+    {"name": "snapshot-schedule", "hour": 1, "fn": run_snapshot_schedule},
+    {"name": "aggregate-daily", "hour": 3, "fn": run_aggregate_daily},
+    {"name": "archive-positions", "hour": 3, "fn": run_archive_positions},
+    {"name": "cleanup-positions", "hour": 4, "fn": run_cleanup_positions},
+    {"name": "refresh-segments", "hour": 5, "day_of_week": 0, "fn": run_refresh_segments},  # Monday
+]

--- a/worker-py/worker/jobs.py
+++ b/worker-py/worker/jobs.py
@@ -15,8 +15,8 @@ class Job(TypedDict, total=False):
 
 JOBS: list[Job] = [
     {"name": "snapshot-schedule", "hour": 1, "fn": run_snapshot_schedule},
+    {"name": "archive-positions", "hour": 2, "fn": run_archive_positions},  # Before aggregate
     {"name": "aggregate-daily", "hour": 3, "fn": run_aggregate_daily},
-    {"name": "archive-positions", "hour": 3, "fn": run_archive_positions},
     {"name": "cleanup-positions", "hour": 4, "fn": run_cleanup_positions},
     {"name": "refresh-segments", "hour": 5, "day_of_week": 0, "fn": run_refresh_segments},
 ]

--- a/worker-py/worker/main.py
+++ b/worker-py/worker/main.py
@@ -1,0 +1,102 @@
+import os
+import sys
+import signal
+import time
+import logging
+from datetime import datetime, timezone
+
+from worker.collector import collect_positions
+from worker.jobs import JOBS
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%H:%M:%S")
+log = logging.getLogger("worker")
+
+INTERVAL_S = 30
+
+
+def check_scheduled_jobs(last_run: dict):
+    now = datetime.now(timezone.utc)
+    hour = now.hour
+    weekday = now.weekday()  # 0=Monday
+    today_key = now.strftime("%Y-%m-%d")
+
+    for job in JOBS:
+        if hour != job["hour"]:
+            continue
+        if job.get("day_of_week") is not None and weekday != job["day_of_week"]:
+            continue
+        run_key = f"{today_key}:{job['name']}"
+        if last_run.get(job["name"]) == run_key:
+            continue
+        last_run[job["name"]] = run_key
+
+        log.info(f"[scheduler] Starting {job['name']}...")
+        try:
+            job["fn"]()
+            log.info(f"[scheduler] {job['name']} completed")
+        except Exception as e:
+            log.error(f"[scheduler] {job['name']} failed: {e}")
+
+
+def main():
+    # CLI mode: run a specific job
+    if len(sys.argv) >= 3 and sys.argv[1] == "run":
+        job_name = sys.argv[2]
+        job = next((j for j in JOBS if j["name"] == job_name), None)
+        if not job:
+            log.error(f"Unknown job: {job_name}")
+            log.info(f"Available: {', '.join(j['name'] for j in JOBS)}")
+            sys.exit(1)
+        log.info(f"[run] Executing {job_name}...")
+        job["fn"]()
+        log.info(f"[run] {job_name} completed")
+        return
+
+    log.info("=== PortoMove Worker (Python/DuckDB) ===")
+    log.info(f"Collection interval: {INTERVAL_S}s")
+    log.info("Scheduled jobs:")
+    days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+    for job in JOBS:
+        day = days[job["day_of_week"]] if job.get("day_of_week") is not None else "daily"
+        log.info(f"  - {job['name']}: {job['hour']:02d}:00 UTC ({day})")
+
+    running = True
+
+    def shutdown(*_):
+        nonlocal running
+        running = False
+
+    signal.signal(signal.SIGTERM, shutdown)
+    signal.signal(signal.SIGINT, shutdown)
+
+    last_run: dict = {}
+    total_collected = 0
+    total_cycles = 0
+    total_errors = 0
+
+    while running:
+        try:
+            n = collect_positions()
+            total_collected += n
+            total_cycles += 1
+            if total_cycles % 10 == 0:
+                log.info(f"[collect] cycle {total_cycles}: {n} positions | total: {total_collected}, errors: {total_errors}")
+            else:
+                log.info(f"[collect] {n} positions")
+        except Exception as e:
+            total_errors += 1
+            log.error(f"[collect] Failed: {e}")
+
+        check_scheduled_jobs(last_run)
+
+        # Sleep in small increments to allow signal handling
+        for _ in range(INTERVAL_S):
+            if not running:
+                break
+            time.sleep(1)
+
+    log.info(f"Shutdown. Total: {total_collected} positions in {total_cycles} cycles, {total_errors} errors.")
+
+
+if __name__ == "__main__":
+    main()

--- a/worker-py/worker/main.py
+++ b/worker-py/worker/main.py
@@ -1,3 +1,4 @@
+"""PortoMove Worker — collects bus positions and runs daily aggregation jobs."""
 import os
 import sys
 import signal
@@ -6,18 +7,18 @@ import logging
 from datetime import datetime, timezone
 
 from worker.collector import collect_positions
-from worker.jobs import JOBS
+from worker.jobs import JOBS, Job
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%H:%M:%S")
 log = logging.getLogger("worker")
 
-INTERVAL_S = 30
+INTERVAL_S = int(os.getenv("COLLECT_INTERVAL_S", "30"))
 
 
-def check_scheduled_jobs(last_run: dict):
+def check_scheduled_jobs(last_run: dict[str, str]) -> None:
     now = datetime.now(timezone.utc)
     hour = now.hour
-    weekday = now.weekday()  # 0=Monday
+    weekday = now.weekday()
     today_key = now.strftime("%Y-%m-%d")
 
     for job in JOBS:
@@ -30,46 +31,45 @@ def check_scheduled_jobs(last_run: dict):
             continue
         last_run[job["name"]] = run_key
 
-        log.info(f"[scheduler] Starting {job['name']}...")
+        log.info("[scheduler] Starting %s...", job["name"])
         try:
             job["fn"]()
-            log.info(f"[scheduler] {job['name']} completed")
-        except Exception as e:
-            log.error(f"[scheduler] {job['name']} failed: {e}")
+            log.info("[scheduler] %s completed", job["name"])
+        except Exception:
+            log.exception("[scheduler] %s failed", job["name"])
 
 
-def main():
+def main() -> None:
     # CLI mode: run a specific job
     if len(sys.argv) >= 3 and sys.argv[1] == "run":
         job_name = sys.argv[2]
         job = next((j for j in JOBS if j["name"] == job_name), None)
         if not job:
-            log.error(f"Unknown job: {job_name}")
-            log.info(f"Available: {', '.join(j['name'] for j in JOBS)}")
+            log.error("Unknown job: %s. Available: %s", job_name, ", ".join(j["name"] for j in JOBS))
             sys.exit(1)
-        log.info(f"[run] Executing {job_name}...")
+        log.info("[run] Executing %s...", job_name)
         job["fn"]()
-        log.info(f"[run] {job_name} completed")
+        log.info("[run] %s completed", job_name)
         return
 
     log.info("=== PortoMove Worker (Python/DuckDB) ===")
-    log.info(f"Collection interval: {INTERVAL_S}s")
+    log.info("Collection interval: %ds", INTERVAL_S)
     log.info("Scheduled jobs:")
     days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
     for job in JOBS:
         day = days[job["day_of_week"]] if job.get("day_of_week") is not None else "daily"
-        log.info(f"  - {job['name']}: {job['hour']:02d}:00 UTC ({day})")
+        log.info("  - %s: %02d:00 UTC (%s)", job["name"], job["hour"], day)
 
     running = True
 
-    def shutdown(*_):
+    def shutdown(*_: object) -> None:
         nonlocal running
         running = False
 
     signal.signal(signal.SIGTERM, shutdown)
     signal.signal(signal.SIGINT, shutdown)
 
-    last_run: dict = {}
+    last_run: dict[str, str] = {}
     total_collected = 0
     total_cycles = 0
     total_errors = 0
@@ -80,22 +80,21 @@ def main():
             total_collected += n
             total_cycles += 1
             if total_cycles % 10 == 0:
-                log.info(f"[collect] cycle {total_cycles}: {n} positions | total: {total_collected}, errors: {total_errors}")
+                log.info("[collect] cycle %d: %d positions | total: %d, errors: %d", total_cycles, n, total_collected, total_errors)
             else:
-                log.info(f"[collect] {n} positions")
-        except Exception as e:
+                log.info("[collect] %d positions", n)
+        except Exception:
             total_errors += 1
-            log.error(f"[collect] Failed: {e}")
+            log.exception("[collect] Failed")
 
         check_scheduled_jobs(last_run)
 
-        # Sleep in small increments to allow signal handling
         for _ in range(INTERVAL_S):
             if not running:
                 break
             time.sleep(1)
 
-    log.info(f"Shutdown. Total: {total_collected} positions in {total_cycles} cycles, {total_errors} errors.")
+    log.info("Shutdown. Total: %d positions in %d cycles, %d errors.", total_collected, total_cycles, total_errors)
 
 
 if __name__ == "__main__":

--- a/worker-py/worker/r2.py
+++ b/worker-py/worker/r2.py
@@ -1,0 +1,18 @@
+import os
+import boto3
+
+_client = None
+BUCKET = os.getenv("R2_BUCKET", "porto-move")
+
+
+def get_r2():
+    global _client
+    if _client is None:
+        _client = boto3.client(
+            "s3",
+            endpoint_url=os.environ["R2_ENDPOINT"],
+            aws_access_key_id=os.environ["R2_ACCESS_KEY_ID"],
+            aws_secret_access_key=os.environ["R2_SECRET_ACCESS_KEY"],
+            region_name="auto",
+        )
+    return _client

--- a/worker-py/worker/schedule.py
+++ b/worker-py/worker/schedule.py
@@ -1,6 +1,6 @@
 """Remaining scheduled jobs: snapshot-schedule, cleanup-positions, refresh-segments."""
-import json
 import logging
+import os
 import time
 from datetime import datetime, timezone, timedelta
 
@@ -11,8 +11,9 @@ from worker.r2 import get_r2, BUCKET
 
 log = logging.getLogger("worker")
 
-OTP_URL = "https://otp.portodigital.pt/otp/routers/default/index/graphql"
+OTP_URL = os.getenv("OTP_URL", "https://otp.portodigital.pt/otp/routers/default/index/graphql")
 OTP_HEADERS = {"Content-Type": "application/json", "Origin": "https://explore.porto.pt"}
+_HTTP = httpx.Client(timeout=60, transport=httpx.HTTPTransport(retries=3))
 
 
 def run_snapshot_schedule():
@@ -37,7 +38,7 @@ def run_snapshot_schedule():
         }
     }"""
 
-    resp = httpx.post(OTP_URL, json={"query": query}, headers=OTP_HEADERS, timeout=60)
+    resp = _HTTP.post(OTP_URL, json={"query": query}, headers=OTP_HEADERS)
     resp.raise_for_status()
     data = resp.json().get("data", {})
     routes = data.get("routes", [])
@@ -122,7 +123,7 @@ def run_refresh_segments():
         }
     }"""
 
-    resp = httpx.post(OTP_URL, json={"query": query}, headers=OTP_HEADERS, timeout=60)
+    resp = _HTTP.post(OTP_URL, json={"query": query}, headers=OTP_HEADERS)
     resp.raise_for_status()
     routes = resp.json().get("data", {}).get("routes", [])
 

--- a/worker-py/worker/schedule.py
+++ b/worker-py/worker/schedule.py
@@ -133,6 +133,9 @@ def run_refresh_segments():
     db = get_duck()
     attach_neon(db)
 
+    # Collect all stops into a local table, then bulk insert to Neon
+    db.execute("CREATE TABLE local_stops (id VARCHAR, route VARCHAR, direction_id INTEGER, stop_seq INTEGER, stop_id VARCHAR, stop_name VARCHAR, lat DOUBLE, lon DOUBLE)")
+
     total_stops = 0
     for route in routes:
         short_name = route.get("shortName", "")
@@ -145,17 +148,26 @@ def run_refresh_segments():
                 if not stop.get("gtfsId"):
                     continue
                 stop_id_key = f"{short_name}:{dir_id}:{seq}"
-                stop_name = stop.get("name") or None
-                # Upsert via postgres_execute
-                name_sql = f"''{stop_name}''" if stop_name else "NULL"
-                db.execute(f"""CALL postgres_execute('neon', '
-                    INSERT INTO "RouteStop" (id, route, "directionId", "stopSequence", "stopId", "stopName", lat, lon)
-                    VALUES (''{stop_id_key}'', ''{short_name}'', {dir_id}, {seq}, ''{stop["gtfsId"]}'', {name_sql}, {stop["lat"]}, {stop["lon"]})
-                    ON CONFLICT (id) DO UPDATE SET
-                        "stopId" = EXCLUDED."stopId", "stopName" = EXCLUDED."stopName",
-                        lat = EXCLUDED.lat, lon = EXCLUDED.lon
-                ')""")
+                db.execute(
+                    "INSERT INTO local_stops VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    [stop_id_key, short_name, dir_id, seq, stop["gtfsId"], stop.get("name"), stop["lat"], stop["lon"]],
+                )
                 total_stops += 1
+
+    if total_stops > 0:
+        db.execute("""CALL postgres_execute('neon', '
+            CREATE TABLE IF NOT EXISTS "_tmp_stops" (id VARCHAR, route VARCHAR, "directionId" INTEGER, "stopSequence" INTEGER, "stopId" VARCHAR, "stopName" VARCHAR, lat DOUBLE PRECISION, lon DOUBLE PRECISION)
+        ')""")
+        db.execute("""CALL postgres_execute('neon', 'TRUNCATE "_tmp_stops"')""")
+        db.execute("""INSERT INTO neon."_tmp_stops" SELECT * FROM local_stops""")
+        db.execute("""CALL postgres_execute('neon', '
+            INSERT INTO "RouteStop" (id, route, "directionId", "stopSequence", "stopId", "stopName", lat, lon)
+            SELECT id, route, "directionId", "stopSequence", "stopId", "stopName", lat, lon FROM "_tmp_stops"
+            ON CONFLICT (id) DO UPDATE SET
+                "stopId" = EXCLUDED."stopId", "stopName" = EXCLUDED."stopName",
+                lat = EXCLUDED.lat, lon = EXCLUDED.lon
+        ')""")
+        db.execute("""CALL postgres_execute('neon', 'DROP TABLE "_tmp_stops"')""")
 
     elapsed = time.time() - start
     log.info(f"[segments] Refreshed {total_stops} stops from {len(routes)} routes in {elapsed:.1f}s")

--- a/worker-py/worker/schedule.py
+++ b/worker-py/worker/schedule.py
@@ -1,0 +1,161 @@
+"""Remaining scheduled jobs: snapshot-schedule, cleanup-positions, refresh-segments."""
+import json
+import logging
+import time
+from datetime import datetime, timezone, timedelta
+
+import httpx
+
+from worker.db import get_duck, attach_neon
+from worker.r2 import get_r2, BUCKET
+
+log = logging.getLogger("worker")
+
+OTP_URL = "https://otp.portodigital.pt/otp/routers/default/index/graphql"
+OTP_HEADERS = {"Content-Type": "application/json", "Origin": "https://explore.porto.pt"}
+
+
+def run_snapshot_schedule():
+    """Fetch today's scheduled trips from OTP and store in ScheduledTripDaily."""
+    start = time.time()
+
+    # Porto local midnight
+    now = datetime.now(timezone.utc)
+    today = now.date()
+    target_epoch = int(datetime(today.year, today.month, today.day, tzinfo=timezone.utc).timestamp())
+    date_str = today.isoformat()
+
+    log.info(f"[snapshot] Fetching OTP timetable for {date_str}")
+
+    query = """{
+        routes {
+            shortName
+            patterns {
+                directionId
+                trips { gtfsId activeDates }
+            }
+        }
+    }"""
+
+    resp = httpx.post(OTP_URL, json={"query": query}, headers=OTP_HEADERS, timeout=60)
+    resp.raise_for_status()
+    data = resp.json().get("data", {})
+    routes = data.get("routes", [])
+
+    if not routes:
+        log.info("[snapshot] No routes from OTP")
+        return
+
+    rows = []
+    for route in routes:
+        short_name = route.get("shortName", "")
+        if not short_name:
+            continue
+        for pattern in route.get("patterns", []):
+            dir_id = pattern.get("directionId")
+            for trip in pattern.get("trips", []):
+                if target_epoch in (trip.get("activeDates") or []):
+                    rows.append((short_name, dir_id, trip["gtfsId"]))
+
+    log.info(f"[snapshot] Found {len(rows)} scheduled trips for {date_str}")
+    if not rows:
+        return
+
+    db = get_duck()
+    attach_neon(db)
+
+    db.execute(f"CALL postgres_execute('neon', 'DELETE FROM \"ScheduledTripDaily\" WHERE date = ''{date_str}''')")
+
+    db.execute("CREATE TABLE local_sched (route VARCHAR, direction_id SMALLINT, trip_id VARCHAR)")
+    db.executemany("INSERT INTO local_sched VALUES (?, ?, ?)", rows)
+    db.execute(f"""
+        INSERT INTO neon."ScheduledTripDaily" (date, route, "directionId", "tripId")
+        SELECT '{date_str}'::DATE, route, direction_id, trip_id FROM local_sched
+    """)
+
+    elapsed = time.time() - start
+    log.info(f"[snapshot] Stored {len(rows)} trips in {elapsed:.1f}s")
+
+
+def run_cleanup_positions():
+    """Delete R2 snapshot objects older than 2 days."""
+    start = time.time()
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=2)).date()
+    r2 = get_r2()
+
+    deleted = 0
+    paginator = r2.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=BUCKET, Prefix="snapshots/"):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            if key == "snapshots/today.json":
+                continue
+            # Extract date from snapshots/YYYY/MM/DD/...
+            parts = key.replace("snapshots/", "").split("/")
+            if len(parts) < 3:
+                continue
+            try:
+                file_date = datetime(int(parts[0]), int(parts[1]), int(parts[2])).date()
+            except (ValueError, IndexError):
+                continue
+            if file_date < cutoff:
+                r2.delete_object(Bucket=BUCKET, Key=key)
+                deleted += 1
+
+    elapsed = time.time() - start
+    log.info(f"[cleanup] Deleted {deleted} snapshots older than {cutoff} in {elapsed:.1f}s")
+
+
+def run_refresh_segments():
+    """Refresh route segments and stops from OTP."""
+    start = time.time()
+    log.info("[segments] Refreshing from OTP...")
+
+    query = """query {
+        routes {
+            shortName
+            patterns {
+                directionId
+                patternGeometry { points }
+                stops { gtfsId name lat lon }
+            }
+        }
+    }"""
+
+    resp = httpx.post(OTP_URL, json={"query": query}, headers=OTP_HEADERS, timeout=60)
+    resp.raise_for_status()
+    routes = resp.json().get("data", {}).get("routes", [])
+
+    if not routes:
+        log.warning("[segments] No routes from OTP")
+        return
+
+    db = get_duck()
+    attach_neon(db)
+
+    total_stops = 0
+    for route in routes:
+        short_name = route.get("shortName", "")
+        if not short_name:
+            continue
+        for pattern in route.get("patterns", []):
+            dir_id = pattern.get("directionId", 0)
+            stops = pattern.get("stops", [])
+            for seq, stop in enumerate(stops):
+                if not stop.get("gtfsId"):
+                    continue
+                stop_id_key = f"{short_name}:{dir_id}:{seq}"
+                stop_name = stop.get("name") or None
+                # Upsert via postgres_execute
+                name_sql = f"''{stop_name}''" if stop_name else "NULL"
+                db.execute(f"""CALL postgres_execute('neon', '
+                    INSERT INTO "RouteStop" (id, route, "directionId", "stopSequence", "stopId", "stopName", lat, lon)
+                    VALUES (''{stop_id_key}'', ''{short_name}'', {dir_id}, {seq}, ''{stop["gtfsId"]}'', {name_sql}, {stop["lat"]}, {stop["lon"]})
+                    ON CONFLICT (id) DO UPDATE SET
+                        "stopId" = EXCLUDED."stopId", "stopName" = EXCLUDED."stopName",
+                        lat = EXCLUDED.lat, lon = EXCLUDED.lon
+                ')""")
+                total_stops += 1
+
+    elapsed = time.time() - start
+    log.info(f"[segments] Refreshed {total_stops} stops from {len(routes)} routes in {elapsed:.1f}s")

--- a/worker/cron_aggregate.go
+++ b/worker/cron_aggregate.go
@@ -46,12 +46,25 @@ func listSnapshotKeys(ctx context.Context, r2 *s3.Client, bucket, dateStr string
 }
 
 func runAggregateDaily(ctx context.Context, pool *pgxpool.Pool, r2 *s3.Client, bucket string) error {
+	return runAggregateDailyWithDate(ctx, pool, r2, bucket, time.Time{})
+}
+
+func runAggregateDailyWithDate(ctx context.Context, pool *pgxpool.Pool, r2 *s3.Client, bucket string, overrideDate time.Time) error {
 	startTime := time.Now()
 
 	now := time.Now().UTC()
-	yesterday := time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.UTC)
-	today := yesterday.AddDate(0, 0, 1)
-	dateStr := yesterday.Format("2006-01-02")
+	var yesterday, today time.Time
+	var dateStr string
+
+	if !overrideDate.IsZero() {
+		yesterday = time.Date(overrideDate.Year(), overrideDate.Month(), overrideDate.Day(), 0, 0, 0, 0, time.UTC)
+		today = yesterday.AddDate(0, 0, 1)
+		dateStr = yesterday.Format("2006-01-02")
+	} else {
+		yesterday = time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.UTC)
+		today = yesterday.AddDate(0, 0, 1)
+		dateStr = yesterday.Format("2006-01-02")
+	}
 
 	log.Printf("[aggregate] Starting for %s", dateStr)
 

--- a/worker/cron_aggregate_incremental.go
+++ b/worker/cron_aggregate_incremental.go
@@ -1,0 +1,733 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const snapshotBatchSize = 500
+
+func runAggregateDailyIncremental(ctx context.Context, pool *pgxpool.Pool, r2 *s3.Client, bucket string, overrideDate time.Time) error {
+	startTime := time.Now()
+
+	now := time.Now().UTC()
+	var yesterday, today time.Time
+	var dateStr string
+
+	if !overrideDate.IsZero() {
+		yesterday = time.Date(overrideDate.Year(), overrideDate.Month(), overrideDate.Day(), 0, 0, 0, 0, time.UTC)
+		today = yesterday.AddDate(0, 0, 1)
+		dateStr = yesterday.Format("2006-01-02")
+	} else {
+		yesterday = time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.UTC)
+		today = yesterday.AddDate(0, 0, 1)
+		dateStr = yesterday.Format("2006-01-02")
+	}
+
+	log.Printf("[aggregate] Starting incremental aggregation for %s", dateStr)
+
+	// Create temporary staging table for positions
+	_, err := pool.Exec(ctx, `
+		CREATE UNLOGGED TABLE IF NOT EXISTS "PositionStagingTemp" (
+			id BIGSERIAL PRIMARY KEY,
+			"recordedAt" TIMESTAMPTZ NOT NULL,
+			"vehicleId" TEXT NOT NULL,
+			"vehicleNum" TEXT,
+			route TEXT NOT NULL,
+			"directionId" SMALLINT,
+			lat DOUBLE PRECISION NOT NULL,
+			lon DOUBLE PRECISION NOT NULL,
+			speed REAL,
+			"tripId" TEXT
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("create staging table: %w", err)
+	}
+	defer pool.Exec(ctx, `DROP TABLE IF EXISTS "PositionStagingTemp"`)
+
+	// Clear staging table
+	_, err = pool.Exec(ctx, `TRUNCATE TABLE "PositionStagingTemp"`)
+	if err != nil {
+		return fmt.Errorf("truncate staging: %w", err)
+	}
+
+	// List snapshot files
+	keys, err := listSnapshotKeys(ctx, r2, bucket, dateStr)
+	if err != nil {
+		return fmt.Errorf("list snapshots: %w", err)
+	}
+	if len(keys) == 0 {
+		log.Printf("[aggregate] No snapshots found for %s", dateStr)
+		return nil
+	}
+	log.Printf("[aggregate] Found %d snapshot files", len(keys))
+
+	// Pre-load segments
+	segRows, err := pool.Query(ctx, `SELECT id, route, "directionId", "segmentIndex", "startLat", "startLon", "endLat", "endLon", "midLat", "midLon", "lengthM", geometry FROM "RouteSegment"`)
+	if err != nil {
+		return fmt.Errorf("load segments: %w", err)
+	}
+	var segDefs []SegmentDef
+	for segRows.Next() {
+		var s SegmentDef
+		var geomJSON []byte
+		err := segRows.Scan(&s.ID, &s.Route, &s.DirectionID, &s.SegmentIndex,
+			&s.StartLat, &s.StartLon, &s.EndLat, &s.EndLon,
+			&s.MidLat, &s.MidLon, &s.LengthM, &geomJSON)
+		if err != nil {
+			segRows.Close()
+			return fmt.Errorf("scan segment: %w", err)
+		}
+		json.Unmarshal(geomJSON, &s.Geometry)
+		segDefs = append(segDefs, s)
+	}
+	segRows.Close()
+
+	// Pre-load route stops
+	type routeStop struct {
+		Route       string
+		DirectionID int
+		StopSeq     int
+		StopID      string
+		StopName    *string
+		Lat         float64
+		Lon         float64
+	}
+	stopsByRoute := make(map[string][]routeStop)
+	rsRows, err := pool.Query(ctx, `SELECT route, "directionId", "stopSequence", "stopId", "stopName", lat, lon FROM "RouteStop"`)
+	if err != nil {
+		return fmt.Errorf("load route stops: %w", err)
+	}
+	for rsRows.Next() {
+		var rs routeStop
+		if err := rsRows.Scan(&rs.Route, &rs.DirectionID, &rs.StopSeq, &rs.StopID, &rs.StopName, &rs.Lat, &rs.Lon); err != nil {
+			rsRows.Close()
+			return fmt.Errorf("scan route stop: %w", err)
+		}
+		stopsByRoute[rs.Route] = append(stopsByRoute[rs.Route], rs)
+	}
+	rsRows.Close()
+
+	// Process snapshots in batches
+	var totalPositions int64
+	hourlySegmentSpeeds := make(map[string][]float64)
+	stopArrivals := make(map[string][]int64)
+	lastSeenAt := make(map[string]int64)
+
+	batchNum := 0
+	for batchStart := 0; batchStart < len(keys); batchStart += snapshotBatchSize {
+		batchEnd := batchStart + snapshotBatchSize
+		if batchEnd > len(keys) {
+			batchEnd = len(keys)
+		}
+		batchNum++
+
+		// Process each snapshot in this batch
+		var batchPositions []PositionPoint
+		for _, key := range keys[batchStart:batchEnd] {
+			out, err := r2.GetObject(ctx, &s3.GetObjectInput{Bucket: &bucket, Key: &key})
+			if err != nil {
+				log.Printf("[aggregate] WARNING: failed to fetch %s: %v", key, err)
+				continue
+			}
+			body, err := io.ReadAll(out.Body)
+			out.Body.Close()
+			if err != nil {
+				log.Printf("[aggregate] WARNING: failed to read %s: %v", key, err)
+				continue
+			}
+
+			var snap SnapshotFile
+			if err := json.Unmarshal(body, &snap); err != nil {
+				log.Printf("[aggregate] WARNING: failed to parse %s: %v", key, err)
+				continue
+			}
+
+			recordedAt, err := time.Parse(time.RFC3339, snap.RecordedAt)
+			if err != nil {
+				continue
+			}
+
+			for _, p := range snap.Positions {
+				if p.Route == "" {
+					continue
+				}
+				pp := PositionPoint{
+					RecordedAt: recordedAt,
+					VehicleID:  p.VehicleID,
+					Route:      p.Route,
+					Lat:        p.Lat,
+					Lon:        p.Lon,
+					Speed:      p.Speed,
+				}
+				if p.VehicleNum != "" {
+					pp.VehicleNum = &p.VehicleNum
+				}
+				if p.TripID != "" {
+					pp.TripID = &p.TripID
+				}
+				pp.DirectionID = p.DirectionID
+
+				batchPositions = append(batchPositions, pp)
+
+				// Segment speeds (keep in memory - small)
+				if pp.Speed != nil && *pp.Speed > 0 && len(segDefs) > 0 {
+					segID := snapToSegment(pp.Lat, pp.Lon, pp.Route, pp.DirectionID, segDefs, 150)
+					if segID != "" {
+						hour := time.Date(pp.RecordedAt.Year(), pp.RecordedAt.Month(), pp.RecordedAt.Day(), pp.RecordedAt.Hour(), 0, 0, 0, time.UTC)
+						key := segID + ":" + hour.Format(time.RFC3339)
+						hourlySegmentSpeeds[key] = append(hourlySegmentSpeeds[key], float64(*pp.Speed))
+					}
+				}
+
+				// Stop arrivals (keep in memory - small)
+				stopsForRoute := stopsByRoute[pp.Route]
+				if len(stopsForRoute) > 0 {
+					var bestStop *routeStop
+					bestDist := math.Inf(1)
+					for i := range stopsForRoute {
+						rs := &stopsForRoute[i]
+						if pp.DirectionID != nil && rs.DirectionID != int(*pp.DirectionID) {
+							continue
+						}
+						dist := haversineM(pp.Lat, pp.Lon, rs.Lat, rs.Lon)
+						if dist < bestDist && dist <= 80 {
+							bestDist = dist
+							bestStop = rs
+						}
+					}
+					if bestStop != nil {
+						dirStr := "x"
+						if pp.DirectionID != nil {
+							dirStr = fmt.Sprintf("%d", *pp.DirectionID)
+						}
+						stopKey := pp.Route + ":" + dirStr + ":" + bestStop.StopID
+						dedupeKey := pp.VehicleID + ":" + stopKey
+						ts := pp.RecordedAt.UnixMilli()
+						last, exists := lastSeenAt[dedupeKey]
+						if !exists || ts-last >= 3*60*1000 {
+							lastSeenAt[dedupeKey] = ts
+							stopArrivals[stopKey] = append(stopArrivals[stopKey], ts)
+						}
+					}
+				}
+
+				totalPositions++
+			}
+
+			// Free memory immediately
+			body = nil
+			snap.Positions = nil
+		}
+
+		// Write batch positions to staging table
+		if len(batchPositions) > 0 {
+			for i := 0; i < len(batchPositions); i += 1000 {
+				end := i + 1000
+				if end > len(batchPositions) {
+					end = len(batchPositions)
+				}
+				chunk := batchPositions[i:end]
+
+				query := `INSERT INTO "PositionStagingTemp" ("recordedAt", "vehicleId", "vehicleNum", route, "directionId", lat, lon, speed, "tripId") VALUES `
+				var args []interface{}
+				var placeholders []string
+				for j, p := range chunk {
+					base := j * 9
+					placeholders = append(placeholders, fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)",
+						base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8, base+9))
+					args = append(args, p.RecordedAt, p.VehicleID, p.VehicleNum, p.Route, p.DirectionID, p.Lat, p.Lon, p.Speed, p.TripID)
+				}
+				query += strings.Join(placeholders, ",")
+				if _, err := pool.Exec(ctx, query, args...); err != nil {
+					return fmt.Errorf("insert positions batch: %w", err)
+				}
+			}
+		}
+
+		log.Printf("[aggregate] Batch %d/%d: %d positions loaded", batchNum, (len(keys)+snapshotBatchSize-1)/snapshotBatchSize, len(batchPositions))
+
+		// Clear batch positions to free memory
+		batchPositions = nil
+	}
+
+	log.Printf("[aggregate] Processed %d positions from %d files in %d batches", totalPositions, len(keys), batchNum)
+
+	// Trip reconstruction from staging table (stream by vehicle)
+	log.Printf("[aggregate] Reconstructing trips from staging table...")
+
+	// Get all unique vehicles
+	vehicleRows, err := pool.Query(ctx, `SELECT DISTINCT "vehicleId" FROM "PositionStagingTemp" ORDER BY "vehicleId"`)
+	if err != nil {
+		return fmt.Errorf("get vehicles: %w", err)
+	}
+	var vehicles []string
+	for vehicleRows.Next() {
+		var v string
+		if err := vehicleRows.Scan(&v); err != nil {
+			vehicleRows.Close()
+			return fmt.Errorf("scan vehicle: %w", err)
+		}
+		vehicles = append(vehicles, v)
+	}
+	vehicleRows.Close()
+
+	var allTrips []ReconstructedTrip
+	processedVehicles := 0
+
+	// Process vehicles in batches of 50 to avoid loading all at once
+	for batchStart := 0; batchStart < len(vehicles); batchStart += 50 {
+		batchEnd := batchStart + 50
+		if batchEnd > len(vehicles) {
+			batchEnd = len(vehicles)
+		}
+
+		for _, vehicleID := range vehicles[batchStart:batchEnd] {
+			// Stream positions for this vehicle from staging table
+			posRows, err := pool.Query(ctx, `
+				SELECT "recordedAt", "vehicleId", "vehicleNum", route, "directionId", lat, lon, speed, "tripId"
+				FROM "PositionStagingTemp"
+				WHERE "vehicleId" = $1
+				ORDER BY "recordedAt"
+			`, vehicleID)
+			if err != nil {
+				return fmt.Errorf("get positions for vehicle %s: %w", vehicleID, err)
+			}
+
+			var positions []PositionPoint
+			for posRows.Next() {
+				var p PositionPoint
+				if err := posRows.Scan(&p.RecordedAt, &p.VehicleID, &p.VehicleNum, &p.Route, &p.DirectionID, &p.Lat, &p.Lon, &p.Speed, &p.TripID); err != nil {
+					posRows.Close()
+					return fmt.Errorf("scan position: %w", err)
+				}
+				positions = append(positions, p)
+			}
+			posRows.Close()
+
+			// Group by route+direction and reconstruct trips
+			byRouteDir := make(map[string][]PositionPoint)
+			for _, p := range positions {
+				r := p.Route
+				dirStr := "x"
+				if p.DirectionID != nil {
+					dirStr = fmt.Sprintf("%d", *p.DirectionID)
+				}
+				key := p.VehicleID + ":" + r + ":" + dirStr
+				byRouteDir[key] = append(byRouteDir[key], p)
+			}
+
+			for _, groupPositions := range byRouteDir {
+				allTrips = append(allTrips, reconstructTrips(groupPositions, 10)...)
+			}
+
+			processedVehicles++
+			if processedVehicles%100 == 0 {
+				log.Printf("[aggregate] Reconstructed trips for %d/%d vehicles", processedVehicles, len(vehicles))
+			}
+
+			// Free memory for this vehicle
+			positions = nil
+		}
+	}
+
+	log.Printf("[aggregate] Reconstructed %d trips from %d vehicles", len(allTrips), len(vehicles))
+
+	// Store trip logs
+	if len(allTrips) > 0 {
+		_, err := pool.Exec(ctx, `DELETE FROM "TripLog" WHERE date = $1`, yesterday)
+		if err != nil {
+			return fmt.Errorf("delete old trips: %w", err)
+		}
+		for i := 0; i < len(allTrips); i += 500 {
+			end := i + 500
+			if end > len(allTrips) {
+				end = len(allTrips)
+			}
+			batch := allTrips[i:end]
+			query := `INSERT INTO "TripLog" (date, "vehicleId", "vehicleNum", route, "tripId", "directionId", "startedAt", "endedAt", "runtimeSecs", positions, "avgSpeed") VALUES `
+			var args []interface{}
+			var placeholders []string
+			for j, t := range batch {
+				base := j * 11
+				placeholders = append(placeholders, fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)",
+					base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8, base+9, base+10, base+11))
+				var avgSpeed *float64
+				if t.AvgSpeed > 0 {
+					v := t.AvgSpeed
+					avgSpeed = &v
+				}
+				args = append(args, yesterday, t.VehicleID, t.VehicleNum, t.Route, t.TripID, t.DirectionID, t.StartedAt, t.EndedAt, t.RuntimeSecs, t.Positions, avgSpeed)
+			}
+			query += strings.Join(placeholders, ",")
+			if _, err := pool.Exec(ctx, query, args...); err != nil {
+				return fmt.Errorf("insert trips: %w", err)
+			}
+		}
+	}
+
+	// Segment speed aggregation (from memory - small)
+	if len(segDefs) > 0 && len(hourlySegmentSpeeds) > 0 {
+		_, err := pool.Exec(ctx,
+			`DELETE FROM "SegmentSpeedHourly" WHERE "hourStart" >= $1 AND "hourStart" < $2`,
+			yesterday, today)
+		if err != nil {
+			return fmt.Errorf("delete old segment speeds: %w", err)
+		}
+		segByID := make(map[string]*SegmentDef, len(segDefs))
+		for i := range segDefs {
+			segByID[segDefs[i].ID] = &segDefs[i]
+		}
+		type segSpeedRow struct {
+			segmentID   string
+			route       string
+			directionID int
+			hourStart   time.Time
+			avgSpeed    float64
+			medianSpeed float64
+			p10Speed    float64
+			p90Speed    float64
+			sampleCount int
+		}
+		var segSpeedRows []segSpeedRow
+		for key, speeds := range hourlySegmentSpeeds {
+			if len(speeds) < 2 {
+				continue
+			}
+			var segID, hourISO string
+			for i := len(key) - 1; i >= 0; i-- {
+				if key[i] == ':' {
+					candidate := key[:i]
+					if _, ok := segByID[candidate]; ok {
+						segID = candidate
+						hourISO = key[i+1:]
+						break
+					}
+				}
+			}
+			if segID == "" {
+				continue
+			}
+			seg := segByID[segID]
+			hourStart, err := time.Parse(time.RFC3339, hourISO)
+			if err != nil {
+				continue
+			}
+			avg := 0.0
+			for _, s := range speeds {
+				avg += s
+			}
+			avg /= float64(len(speeds))
+			segSpeedRows = append(segSpeedRows, segSpeedRow{
+				segmentID:   segID,
+				route:       seg.Route,
+				directionID: seg.DirectionID,
+				hourStart:   hourStart,
+				avgSpeed:    math.Round(avg*10) / 10,
+				medianSpeed: math.Round(percentile(speeds, 50)*10) / 10,
+				p10Speed:    math.Round(percentile(speeds, 10)*10) / 10,
+				p90Speed:    math.Round(percentile(speeds, 90)*10) / 10,
+				sampleCount: len(speeds),
+			})
+		}
+		hourlySegmentSpeeds = nil
+		for i := 0; i < len(segSpeedRows); i += 500 {
+			end := i + 500
+			if end > len(segSpeedRows) {
+				end = len(segSpeedRows)
+			}
+			batch := segSpeedRows[i:end]
+			query := `INSERT INTO "SegmentSpeedHourly" ("segmentId", route, "directionId", "hourStart", "avgSpeed", "medianSpeed", "p10Speed", "p90Speed", "sampleCount") VALUES `
+			var args []interface{}
+			var placeholders []string
+			for j, r := range batch {
+				base := j * 9
+				placeholders = append(placeholders, fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)",
+					base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8, base+9))
+				args = append(args, r.segmentID, r.route, r.directionID, r.hourStart, r.avgSpeed, r.medianSpeed, r.p10Speed, r.p90Speed, r.sampleCount)
+			}
+			query += strings.Join(placeholders, ",")
+			if _, err := pool.Exec(ctx, query, args...); err != nil {
+				return fmt.Errorf("insert segment speeds: %w", err)
+			}
+		}
+		log.Printf("[aggregate] Computed %d segment speed aggregates", len(segSpeedRows))
+	}
+
+	// Route performance daily
+	routeTrips := make(map[string][]ReconstructedTrip)
+	for _, trip := range allTrips {
+		dirStr := "x"
+		if trip.DirectionID != nil {
+			dirStr = fmt.Sprintf("%d", *trip.DirectionID)
+		}
+		key := trip.Route + ":" + dirStr
+		routeTrips[key] = append(routeTrips[key], trip)
+	}
+	_, err = pool.Exec(ctx, `DELETE FROM "RoutePerformanceDaily" WHERE date = $1`, yesterday)
+	if err != nil {
+		return fmt.Errorf("delete old route perf: %w", err)
+	}
+	type routePerfRow struct {
+		route               string
+		directionID         *int16
+		tripsObserved       int
+		avgHeadwaySecs      *float64
+		headwayAdherencePct *float64
+		excessWaitTimeSecs  *float64
+		avgRuntimeSecs      *int
+		avgCommercialSpeed  *float64
+		bunchingPct         *float64
+		gappingPct          *float64
+	}
+	var routePerfRows []routePerfRow
+	for key, trips := range routeTrips {
+		parts := strings.SplitN(key, ":", 2)
+		route := parts[0]
+		var directionID *int16
+		if parts[1] != "x" {
+			var d int16
+			fmt.Sscanf(parts[1], "%d", &d)
+			directionID = &d
+		}
+		startTimes := make([]int64, len(trips))
+		for i, t := range trips {
+			startTimes[i] = t.StartedAt.UnixMilli()
+		}
+		sort.Slice(startTimes, func(i, j int) bool { return startTimes[i] < startTimes[j] })
+		headwayMetrics := computeHeadwayMetrics(startTimes, nil)
+		var runtimes []float64
+		for _, t := range trips {
+			if t.RuntimeSecs > 60 {
+				runtimes = append(runtimes, float64(t.RuntimeSecs))
+			}
+		}
+		var avgRuntime *int
+		if len(runtimes) > 0 {
+			sum := 0.0
+			for _, r := range runtimes {
+				sum += r
+			}
+			v := int(math.Round(sum / float64(len(runtimes))))
+			avgRuntime = &v
+		}
+		var speeds []float64
+		for _, t := range trips {
+			if t.AvgSpeed > 0 {
+				speeds = append(speeds, t.AvgSpeed)
+			}
+		}
+		var avgCommercialSpeed *float64
+		if len(speeds) > 0 {
+			sum := 0.0
+			for _, s := range speeds {
+				sum += s
+			}
+			v := math.Round(sum/float64(len(speeds))*10) / 10
+			avgCommercialSpeed = &v
+		}
+		rp := routePerfRow{
+			route:              route,
+			directionID:        directionID,
+			tripsObserved:      len(trips),
+			avgRuntimeSecs:     avgRuntime,
+			avgCommercialSpeed: avgCommercialSpeed,
+		}
+		if headwayMetrics != nil {
+			ahs := float64(headwayMetrics.AvgHeadwaySecs)
+			rp.avgHeadwaySecs = &ahs
+			rp.headwayAdherencePct = &headwayMetrics.HeadwayAdherencePct
+			ewt := float64(headwayMetrics.ExcessWaitTimeSecs)
+			rp.excessWaitTimeSecs = &ewt
+			rp.bunchingPct = &headwayMetrics.BunchingPct
+			rp.gappingPct = &headwayMetrics.GappingPct
+		}
+		routePerfRows = append(routePerfRows, rp)
+	}
+	if len(routePerfRows) > 0 {
+		for i := 0; i < len(routePerfRows); i += 500 {
+			end := i + 500
+			if end > len(routePerfRows) {
+				end = len(routePerfRows)
+			}
+			batch := routePerfRows[i:end]
+			query := `INSERT INTO "RoutePerformanceDaily" (date, route, "directionId", "tripsObserved", "avgHeadwaySecs", "headwayAdherencePct", "excessWaitTimeSecs", "avgRuntimeSecs", "avgCommercialSpeed", "bunchingPct", "gappingPct") VALUES `
+			var args []interface{}
+			var placeholders []string
+			for j, r := range batch {
+				base := j * 11
+				placeholders = append(placeholders, fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)",
+					base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8, base+9, base+10, base+11))
+				args = append(args, yesterday, r.route, r.directionID, r.tripsObserved, r.avgHeadwaySecs, r.headwayAdherencePct, r.excessWaitTimeSecs, r.avgRuntimeSecs, r.avgCommercialSpeed, r.bunchingPct, r.gappingPct)
+			}
+			query += strings.Join(placeholders, ",")
+			if _, err := pool.Exec(ctx, query, args...); err != nil {
+				return fmt.Errorf("insert route perf: %w", err)
+			}
+		}
+	}
+	log.Printf("[aggregate] Computed performance for %d route-directions", len(routePerfRows))
+
+	// Stop headway irregularity (from memory - small)
+	if len(stopArrivals) > 0 {
+		_, err := pool.Exec(ctx, `DELETE FROM "StopHeadwayDaily" WHERE date = $1`, yesterday)
+		if err != nil {
+			return fmt.Errorf("delete old stop headway: %w", err)
+		}
+		type headwayRow struct {
+			route          string
+			directionID    *int16
+			stopID         string
+			stopName       *string
+			stopSequence   int
+			avgHeadwaySecs int
+			headwayStdDev  float64
+			observations   int
+		}
+		var headwayRows []headwayRow
+		for stopKey, arrivals := range stopArrivals {
+			if len(arrivals) < 3 {
+				continue
+			}
+			sort.Slice(arrivals, func(i, j int) bool { return arrivals[i] < arrivals[j] })
+			headways := make([]float64, 0, len(arrivals)-1)
+			for i := 1; i < len(arrivals); i++ {
+				headways = append(headways, float64(arrivals[i]-arrivals[i-1])/1000.0)
+			}
+			avg := 0.0
+			for _, h := range headways {
+				avg += h
+			}
+			avg /= float64(len(headways))
+			variance := 0.0
+			for _, h := range headways {
+				variance += (h - avg) * (h - avg)
+			}
+			variance /= float64(len(headways))
+			stdDev := math.Sqrt(variance)
+			firstColon := strings.Index(stopKey, ":")
+			secondColon := strings.Index(stopKey[firstColon+1:], ":") + firstColon + 1
+			route := stopKey[:firstColon]
+			dirStr := stopKey[firstColon+1 : secondColon]
+			stopID := stopKey[secondColon+1:]
+			var directionID *int16
+			if dirStr != "x" {
+				var d int16
+				fmt.Sscanf(dirStr, "%d", &d)
+				directionID = &d
+			}
+			var stopName *string
+			stopSeq := 0
+			stopsForRoute := stopsByRoute[route]
+			for _, rs := range stopsForRoute {
+				if rs.StopID == stopID && (directionID == nil || rs.DirectionID == int(*directionID)) {
+					stopName = rs.StopName
+					stopSeq = rs.StopSeq
+					break
+				}
+			}
+			headwayRows = append(headwayRows, headwayRow{
+				route:          route,
+				directionID:    directionID,
+				stopID:         stopID,
+				stopName:       stopName,
+				stopSequence:   stopSeq,
+				avgHeadwaySecs: int(math.Round(avg)),
+				headwayStdDev:  math.Round(stdDev*10) / 10,
+				observations:   len(arrivals),
+			})
+		}
+		for i := 0; i < len(headwayRows); i += 500 {
+			end := i + 500
+			if end > len(headwayRows) {
+				end = len(headwayRows)
+			}
+			batch := headwayRows[i:end]
+			query := `INSERT INTO "StopHeadwayDaily" (date, route, "directionId", "stopId", "stopName", "stopSequence", "avgHeadwaySecs", "headwayStdDev", observations) VALUES `
+			var args []interface{}
+			var placeholders []string
+			for j, r := range batch {
+				base := j * 9
+				placeholders = append(placeholders, fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)",
+					base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8, base+9))
+				args = append(args, yesterday, r.route, r.directionID, r.stopID, r.stopName, r.stopSequence, r.avgHeadwaySecs, r.headwayStdDev, r.observations)
+			}
+			query += strings.Join(placeholders, ",")
+			if _, err := pool.Exec(ctx, query, args...); err != nil {
+				return fmt.Errorf("insert stop headway: %w", err)
+			}
+		}
+		log.Printf("[aggregate] Computed headway irregularity for %d stops", len(headwayRows))
+	}
+
+	// Network summary
+	uniqueVehicles := make(map[string]struct{})
+	for _, t := range allTrips {
+		uniqueVehicles[t.VehicleID] = struct{}{}
+	}
+	var allSpeeds []float64
+	var allEwt []float64
+	for _, r := range routePerfRows {
+		if r.avgCommercialSpeed != nil {
+			allSpeeds = append(allSpeeds, *r.avgCommercialSpeed)
+		}
+		if r.excessWaitTimeSecs != nil {
+			allEwt = append(allEwt, *r.excessWaitTimeSecs)
+		}
+	}
+	var networkAvgSpeed, networkAvgEwt *float64
+	if len(allSpeeds) > 0 {
+		sum := 0.0
+		for _, s := range allSpeeds {
+			sum += s
+		}
+		v := math.Round(sum/float64(len(allSpeeds))*10) / 10
+		networkAvgSpeed = &v
+	}
+	if len(allEwt) > 0 {
+		sum := 0.0
+		for _, e := range allEwt {
+			sum += e
+		}
+		v := math.Round(sum / float64(len(allEwt)))
+		networkAvgEwt = &v
+	}
+	var worstRoute *string
+	var worstEwt *float64
+	for _, r := range routePerfRows {
+		if r.excessWaitTimeSecs != nil && (worstEwt == nil || *r.excessWaitTimeSecs > *worstEwt) {
+			worstEwt = r.excessWaitTimeSecs
+			worstRoute = &r.route
+		}
+	}
+	_, err = pool.Exec(ctx, `
+		INSERT INTO "NetworkSummaryDaily" (date, "activeVehicles", "totalTrips", "avgCommercialSpeed", "avgExcessWaitTime", "worstRoute", "worstRouteEwt", "positionsCollected")
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		ON CONFLICT (date) DO UPDATE SET
+			"activeVehicles" = EXCLUDED."activeVehicles",
+			"totalTrips" = EXCLUDED."totalTrips",
+			"avgCommercialSpeed" = EXCLUDED."avgCommercialSpeed",
+			"avgExcessWaitTime" = EXCLUDED."avgExcessWaitTime",
+			"worstRoute" = EXCLUDED."worstRoute",
+			"worstRouteEwt" = EXCLUDED."worstRouteEwt",
+			"positionsCollected" = EXCLUDED."positionsCollected"
+	`, yesterday, len(uniqueVehicles), len(allTrips), networkAvgSpeed, networkAvgEwt, worstRoute, worstEwt, totalPositions)
+	if err != nil {
+		return fmt.Errorf("upsert network summary: %w", err)
+	}
+
+	elapsed := time.Since(startTime)
+	log.Printf("[aggregate] Complete for %s: %d positions, %d trips in %s", dateStr, totalPositions, len(allTrips), elapsed)
+	return nil
+}

--- a/worker/main.go
+++ b/worker/main.go
@@ -71,34 +71,39 @@ func main() {
 				return runRefreshSegments(ctx, pool)
 			}},
 		}
+
+		// --- CLI mode: run a specific job and exit ---
+		if len(os.Args) >= 3 && os.Args[1] == "run" {
+			jobName := os.Args[2]
+			var target *scheduledJob
+			for i := range jobs {
+				if jobs[i].name == jobName {
+					target = &jobs[i]
+					break
+				}
+			}
+			if target == nil {
+				log.Printf("Unknown job: %s", jobName)
+				log.Printf("Available jobs:")
+				for _, j := range jobs {
+					log.Printf("  - %s", j.name)
+				}
+				os.Exit(1)
+			}
+			log.Printf("[run] Executing %s...", target.name)
+			if err := target.fn(ctx); err != nil {
+				log.Fatalf("[run] %s failed: %v", target.name, err)
+			}
+			log.Printf("[run] %s completed successfully", target.name)
+			return
+		}
 	} else {
 		log.Println("WARNING: DATABASE_URL not set — scheduled jobs (aggregate, archive, cleanup) disabled")
-	}
 
-	// --- CLI mode: run a specific job and exit ---
-	if len(os.Args) >= 3 && os.Args[1] == "run" {
-		jobName := os.Args[2]
-		var target *scheduledJob
-		for i := range jobs {
-			if jobs[i].name == jobName {
-				target = &jobs[i]
-				break
-			}
+		// CLI mode without DATABASE_URL - list available jobs
+		if len(os.Args) >= 3 && os.Args[1] == "run" {
+			log.Fatal("[run] DATABASE_URL not configured — cannot run scheduled jobs that require database")
 		}
-		if target == nil {
-			log.Printf("Unknown job: %s", jobName)
-			log.Printf("Available jobs:")
-			for _, j := range jobs {
-				log.Printf("  - %s", j.name)
-			}
-			os.Exit(1)
-		}
-		log.Printf("[run] Executing %s...", target.name)
-		if err := target.fn(ctx); err != nil {
-			log.Fatalf("[run] %s failed: %v", target.name, err)
-		}
-		log.Printf("[run] %s completed successfully", target.name)
-		return
 	}
 
 	maskedURL := maskDatabaseURL(dbURL)

--- a/worker/main.go
+++ b/worker/main.go
@@ -59,7 +59,7 @@ func main() {
 				return runSnapshotSchedule(ctx, pool)
 			}},
 			{name: "aggregate-daily", hour: 3, dayOfWeek: nil, fn: func(ctx context.Context) error {
-				return runAggregateDaily(ctx, pool, r2, bucket)
+				return runAggregateDailyIncremental(ctx, pool, r2, bucket, time.Time{})
 			}},
 			{name: "archive-positions", hour: 3, dayOfWeek: nil, fn: func(ctx context.Context) error {
 				return runArchivePositions(ctx, r2, bucket)
@@ -90,6 +90,23 @@ func main() {
 				}
 				os.Exit(1)
 			}
+
+			// Support DATE env var for aggregate-daily to backfill historical data
+			if target.name == "aggregate-daily" {
+				if dateStr := os.Getenv("DATE"); dateStr != "" {
+					overrideDate, err := time.Parse("2006-01-02", dateStr)
+					if err != nil {
+						log.Fatalf("[run] Invalid DATE format (use YYYY-MM-DD): %v", err)
+					}
+					log.Printf("[run] Using date override: %s", dateStr)
+					if err := runAggregateDailyIncremental(ctx, pool, r2, bucket, overrideDate); err != nil {
+						log.Fatalf("[run] aggregate-daily failed: %v", err)
+					}
+					log.Printf("[run] aggregate-daily completed successfully")
+					return
+				}
+			}
+
 			log.Printf("[run] Executing %s...", target.name)
 			if err := target.fn(ctx); err != nil {
 				log.Fatalf("[run] %s failed: %v", target.name, err)
@@ -100,7 +117,7 @@ func main() {
 	} else {
 		log.Println("WARNING: DATABASE_URL not set — scheduled jobs (aggregate, archive, cleanup) disabled")
 
-		// CLI mode without DATABASE_URL - list available jobs
+		// CLI mode without DATABASE_URL
 		if len(os.Args) >= 3 && os.Args[1] == "run" {
 			log.Fatal("[run] DATABASE_URL not configured — cannot run scheduled jobs that require database")
 		}


### PR DESCRIPTION
## Summary

Replaces the Go worker with a Python/DuckDB implementation to reduce Neon compute costs by ~95%.

## Problem

The Go worker's `aggregate-daily` job was keeping Neon's compute active for 10-30 minutes using a staging table approach, driving up costs. The 512MB Fly.io VM also had OOM issues with in-memory processing.

## Solution

- **DuckDB 1.5.3** handles all data processing with automatic spill-to-disk
- **`r2://` protocol** reads snapshots directly from Cloudflare R2 (no manual download loop)
- **DuckDB postgres extension** writes results to Neon (binary wire protocol)
- **Trip reconstruction in pure SQL** using window functions
- **Archive job** is a single `COPY TO` Parquet statement
- **~500 lines** vs ~1200 in Go

## Neon cost impact

DB is only active for:
- ~2s to read segments/stops
- ~5-10s to COPY final results

Instead of 10-30 minutes of staging table operations.

## What was tested

- [x] DuckDB 1.5.3 `r2://` protocol reads from R2
- [x] DuckDB postgres extension connects to Neon
- [x] Full pipeline: R2 read → DuckDB process → Neon write
- [x] Python imports and module structure verified

## Migration steps

1. Update `fly.toml` to point to `worker-py/Dockerfile`
2. Set same env vars (DATABASE_URL, R2_ENDPOINT, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET)
3. Deploy
4. Remove old `worker/` directory after validation